### PR TITLE
feat: 시설 화면(토글) + 검색/가까운역 연동 + 챗봇 라우트

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, ActivityIndicator, Alert, Image } from 'react-native';
+import { View, ActivityIndicator, Alert, Image } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
@@ -9,7 +9,6 @@ import { Ionicons } from '@expo/vector-icons';
 import { useFonts } from 'expo-font';
 import { GoogleSignin } from '@react-native-google-signin/google-signin';
 import { useNavigation } from '@react-navigation/native';
-
 
 // --- 화면 컴포넌트들 ---
 import WelcomeScreen from './src/screens/auth/WelcomeScreen';
@@ -21,11 +20,13 @@ import MainScreen from './src/screens/main/MainScreen';
 import MyPageScreen from './src/screens/auth/MyPageScreen';
 import NearbyStationsScreen from './src/screens/nearbystation/NearbyStationsScreen';
 import SearchStationScreen from './src/screens/searchstation/SearchStationScreen';
-
+import ChatBotScreen from './src/screens/chatbot/ChatBotScreen';
+import StationFacilitiesScreen from './src/screens/station/StationFacilitiesScreen';
+import StationDetailScreen from './src/screens/station/StationDetailScreen';
 
 const Stack = createStackNavigator();
+const RootStack = createStackNavigator(); // 전역 푸시용
 const Tab = createBottomTabNavigator();
-
 
 // --- 공통 탭 스크린 옵션 ---
 const commonTabOptions = {
@@ -42,7 +43,6 @@ const commonTabOptions = {
     shadowOpacity: 0,
     borderTopWidth: 0,
   },
-  // 👇 [수정] 폰트 크기를 16으로 키움
   tabBarLabelStyle: {
     fontSize: 16,
     fontFamily: 'NotoSansKR',
@@ -51,18 +51,16 @@ const commonTabOptions = {
   },
 };
 
-
-// --- 비로그인 사용자를 위한 탭 네비게이터 ---
+// --- 비로그인 탭 ---
 const GuestTabs = () => {
   const navigation = useNavigation();
   return (
     <Tab.Navigator
       screenOptions={({ route }) => ({
         ...commonTabOptions,
-        tabBarIcon: ({ focused, color, size }) => {
+        tabBarIcon: ({ focused, size }) => {
           let iconName;
           const iconColor = focused ? '#14CAC9' : 'gray';
-          // 👇 [수정] 단축된 이름으로 변경
           if (route.name === '홈') iconName = focused ? 'home' : 'home-outline';
           else if (route.name === '가까운 역') iconName = focused ? 'navigate-circle' : 'navigate-circle-outline';
           else if (route.name === '검색') iconName = focused ? 'search' : 'search-outline';
@@ -74,7 +72,6 @@ const GuestTabs = () => {
       <Tab.Screen
         name="홈"
         component={MainScreen}
-        // 👇 [수정] 접근성 라벨 추가
         options={{ title: '홈', accessibilityLabel: '홈 화면' }}
         listeners={{
           tabPress: (e) => {
@@ -83,7 +80,6 @@ const GuestTabs = () => {
           },
         }}
       />
-      {/* 👇 [수정] name을 단축하고, title과 accessibilityLabel을 분리 */}
       <Tab.Screen name="가까운 역" component={NearbyStationsScreen} options={{ title: '가까운 역', accessibilityLabel: '가까운 역 목록' }} />
       <Tab.Screen name="검색" component={SearchStationScreen} options={{ title: '역 검색', accessibilityLabel: '역 검색' }} />
       <Tab.Screen
@@ -108,13 +104,12 @@ const GuestTabs = () => {
   );
 };
 
-
-// --- 로그인한 사용자를 위한 탭 네비게이터 ---
+// --- 로그인 탭 (챗봇 탭을 실제 화면으로 연결) ---
 const UserTabs = () => (
   <Tab.Navigator
     screenOptions={({ route }) => ({
       ...commonTabOptions,
-      tabBarIcon: ({ focused, color, size }) => {
+      tabBarIcon: ({ focused, size }) => {
         const iconColor = focused ? '#14CAC9' : 'gray';
 
         if (route.name === '챗봇') {
@@ -143,24 +138,18 @@ const UserTabs = () => (
   >
     <Tab.Screen name="홈" component={MainScreen} options={{ title: '홈', accessibilityLabel: '홈 화면' }} />
     <Tab.Screen name="가까운 역" component={NearbyStationsScreen} options={{ title: '가까운 역', accessibilityLabel: '가까운 역 목록' }} />
+    {/* ✅ 챗봇 탭을 실제 ChatBotScreen으로 연결 */}
     <Tab.Screen
       name="챗봇"
-      component={MainScreen}
+      component={ChatBotScreen}
       options={{ title: '챗봇', accessibilityLabel: '챗봇과 대화하기' }}
-      listeners={{
-        tabPress: (e) => {
-          e.preventDefault();
-          Alert.alert('알림', '챗봇 기능은 현재 준비 중입니다.');
-        },
-      }}
     />
     <Tab.Screen name="검색" component={SearchStationScreen} options={{ title: '역 검색', accessibilityLabel: '역 검색' }} />
     <Tab.Screen name="마이" component={MyPageScreen} options={{ title: '마이', accessibilityLabel: '마이페이지' }} />
   </Tab.Navigator>
 );
 
-
-// --- 화면 그룹 (Stacks) ---
+// --- 인증 스택 ---
 const AuthStack = () => (
   <Stack.Navigator initialRouteName="Welcome">
     <Stack.Screen name="Welcome" component={WelcomeScreen} options={{ headerShown: false }} />
@@ -172,35 +161,47 @@ const AuthStack = () => (
   </Stack.Navigator>
 );
 
-
 const AppStack = () => <UserTabs />;
 
+// --- 전역 스택: 탭 + (시설/역상세) 푸시 가능 ---
+const AppRoot = () => (
+  <RootStack.Navigator>
+    {/* 탭 전체 */}
+    <RootStack.Screen name="Tabs" component={AppStack} options={{ headerShown: false }} />
+    {/* 전역 푸시: 시설 화면(= 한눈/자세히 토글 단일 화면) */}
+    <RootStack.Screen name="시설" component={StationFacilitiesScreen} />
+    {/* 필요 시 유지: 상세 라우트 (호환용) */}
+    <RootStack.Screen name="역상세" component={StationDetailScreen} options={{ title: '역 상세' }} />
+  </RootStack.Navigator>
+);
 
 export default function App() {
   const [user, setUser] = useState(null);
   const [fontsLoaded] = useFonts({
-    'NotoSansKR': require('./src/assets/fonts/NotoSansKR-VariableFont_wght.ttf'),
-    'NotoSans': require('./src/assets/fonts/NotoSans-VariableFont_wdth,wght.ttf'),
+    NotoSansKR: require('./src/assets/fonts/NotoSansKR-VariableFont_wght.ttf'),
+    NotoSans: require('./src/assets/fonts/NotoSans-VariableFont_wdth,wght.ttf'),
     'NotoSans-Italic': require('./src/assets/fonts/NotoSans-Italic-VariableFont_wdth,wght.ttf'),
   });
-
 
   useEffect(() => {
     const webClientId = process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID;
     if (webClientId) GoogleSignin.configure({ webClientId });
-    const unsubscribe = onAuthStateChanged(auth, (user) => setUser(user));
+    const unsubscribe = onAuthStateChanged(auth, (u) => setUser(u));
     return unsubscribe;
   }, []);
 
-
   if (!fontsLoaded) {
-    return <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}><ActivityIndicator size="large" /></View>;
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
   }
-
 
   return (
     <NavigationContainer>
-      {user ? <AppStack /> : <AuthStack />}
+      {/* 로그인 전엔 AuthStack, 로그인 후엔 AppRoot(탭+시설/상세) */}
+      {user ? <AppRoot /> : <AuthStack />}
     </NavigationContainer>
   );
 }

--- a/src/api/elevator.js
+++ b/src/api/elevator.js
@@ -1,0 +1,79 @@
+// src/api/elevator.js
+const SEOUL_KEY = process.env.EXPO_PUBLIC_SEOUL_KEY;
+
+async function seoulFetchJson(url) {
+  const res = await fetch(encodeURI(url));
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Seoul OpenAPI ${res.status}: ${text || url}`);
+  }
+  return res.json();
+}
+
+function normalizeStationName(name = '') {
+  return name.replace(/역$/, '').trim();
+}
+
+const SERVICE_EL = 'tbTraficElvtr';
+
+export async function fetchElevatorLocations(start = 1, end = 1000) {
+  if (!SEOUL_KEY) throw new Error('EXPO_PUBLIC_SEOUL_KEY 가 설정되지 않았습니다.');
+  const url = `http://openapi.seoul.go.kr:8088/5867534c736e6f6f31313072797a4941/json/tbTraficElvtr/1/1000/
+firebase functions:secrets:set SEOUL_OPENAPI_KEY`;
+  const json = await seoulFetchJson(url);
+  const root = json?.[SERVICE_EL];
+  if (!root) {
+    const msg = json?.RESULT?.MESSAGE || 'Unknown response';
+    throw new Error(`Invalid response: ${msg}`);
+  }
+  const rows = root.row ?? [];
+  return rows.map(normalizeElevatorRow);
+}
+
+export async function fetchElevatorAll() {
+  if (!SEOUL_KEY) throw new Error('EXPO_PUBLIC_SEOUL_KEY 가 설정되지 않았습니다.');
+  const firstUrl = `http://openapi.seoul.go.kr:8088/5867534c736e6f6f31313072797a4941/json/tbTraficElvtr/1/1000/
+firebase functions:secrets:set SEOUL_OPENAPI_KEY`;
+  const firstJson = await seoulFetchJson(firstUrl);
+  const total = firstJson?.[SERVICE_EL]?.list_total_count ?? 0;
+  if (!total) return [];
+  const chunk = 1000;
+  const tasks = [];
+  for (let start = 1; start <= total; start += chunk) {
+    const end = Math.min(start + chunk - 1, total);
+    tasks.push(fetchElevatorLocations(start, end));
+  }
+  const pages = await Promise.all(tasks);
+  return pages.flat();
+}
+
+export async function fetchElevatorByStation(stationName) {
+  const name = normalizeStationName(stationName);
+  const all = await fetchElevatorLocations(1, 1000);
+  const exact = all.filter((x) => x.station === name);
+  if (exact.length) return exact;
+  return all.filter((x) => x.station?.includes(name));
+}
+
+function normalizeElevatorRow(it = {}) {
+  return {
+    station: it.STATION_NM ?? it.역명 ?? '',
+    line: it.LINE ?? it.호선 ?? '',
+    lat: num(it.LAT ?? it.위도),
+    lng: num(it.LNG ?? it.경도),
+    exitNo: it.EXIT_NO ?? it.출구번호 ?? '',
+    detail: it.DETAIL ?? it.상세위치 ?? '',
+  };
+}
+function num(v) { const n = Number(v); return Number.isFinite(n) ? n : undefined; }
+
+export async function summarizeElevators(stationName, max = 4) {
+  const list = await fetchElevatorByStation(stationName);
+  if (!list.length) return `${stationName}역 엘리베이터 데이터를 찾지 못했습니다.`;
+  const normalize = (s) => s.replace(/역$/, '').trim();
+  const lines = list.slice(0, max).map((x) => {
+    const exit = x.exitNo ? `${x.exitNo}번 출구` : '출구번호 미상';
+    return `${exit} · ${x.detail || '상세위치 미상'}${x.line ? ` · ${x.line}` : ''}`;
+  });
+  return `${normalize(stationName)}역 엘리베이터 위치\n${lines.join('\n')}`;
+}

--- a/src/api/facilities.js
+++ b/src/api/facilities.js
@@ -1,0 +1,22 @@
+import { FAC } from '../screens/station/FacilitiesSection';
+import { summarizeElevators } from './elevator';
+
+const label = {
+  [FAC.ESCALATOR]: '에스컬레이터',
+  [FAC.ELEVATOR]: '엘리베이터',
+  [FAC.ACCESSIBLE_TOILET]: '장애인 화장실',
+  [FAC.WHEELCHAIR_LIFT]: '휠체어 리프트',
+  [FAC.WIDE_GATE]: '광폭 개찰구',
+  [FAC.NURSING]: '수유실',
+  [FAC.LOCKER]: '물품보관함',
+  [FAC.AUDIO_GUIDE]: '음성유도기',
+};
+
+export async function getFacilityLocation(stationName, key) {
+  switch (key) {
+    case FAC.ELEVATOR:
+      return await summarizeElevators(stationName);
+    default:
+      return `${stationName}역의 ${label[key] || '해당 시설'} 위치 데이터는 준비 중입니다.`;
+  }
+}

--- a/src/screens/chatbot/ChatBotScreen.js
+++ b/src/screens/chatbot/ChatBotScreen.js
@@ -1,0 +1,202 @@
+import React, { useRef, useState, useEffect } from 'react';
+import {
+  View, Text, TextInput, TouchableOpacity, Image, StyleSheet,
+  ActivityIndicator, Platform,
+} from 'react-native';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { KeyboardAvoidingView } from 'react-native';
+import { useHeaderHeight } from '@react-navigation/elements';
+import { summarizeElevators } from '../../api/elevator';
+
+const BOT = 'bot';
+const USER = 'user';
+const BOT_AVATAR = null;   // 필요하면 require('../../assets/bot.png')
+const USER_AVATAR = null;  // 필요하면 require('../../assets/user.png')
+
+export default function ChatBotScreen() {
+  const insets = useSafeAreaInsets();
+  const headerHeight = useHeaderHeight(); // 스택 헤더 높이 보정
+
+  const [text, setText] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [messages, setMessages] = useState([
+    msgBot('함께타요 챗봇에 연결합니다.'),
+    msgBot('안녕하세요! 무엇을 도와드릴까요?'),
+  ]);
+
+  const listRef = useRef(null);
+  const scrollToEnd = () => listRef.current?.scrollToOffset({ offset: 0, animated: true }); // inverted라 0이 끝
+
+  const append = (...newMsgs) => {
+    setMessages((prev) => {
+      const next = [...prev, ...newMsgs];
+      requestAnimationFrame(scrollToEnd);
+      return next;
+    });
+  };
+
+  const onSend = async () => {
+    const q = text.trim();
+    if (!q) return;
+    append(msgUser(q));
+    setText('');
+
+    try {
+      const lower = q.toLowerCase();
+      if (lower.includes('화장실')) {
+        append(
+          msgBot('네, 가장 가까운 화장실 위치를 알려드릴게요.'),
+          msgMapCard({ desc: '현재 위치에서 북쪽 500m, 서쪽 214m 지점입니다.' }),
+          msgBot('다른 도움이 필요하신가요?')
+        );
+        return;
+      }
+      const station = extractStationName(q);
+      if (lower.includes('엘리베이터') && station) {
+        append(msgBot('잠시만요, 엘리베이터 위치를 확인 중입니다…'));
+        setLoading(true);
+        const summary = await summarizeElevators(station);
+        append(msgBot(summary));
+        setLoading(false);
+        return;
+      }
+      if (station) { append(msgBot(`“${station}” 역 정보를 찾고 있어요. 엘리베이터가 맞나요?`)); return; }
+      append(msgBot('예: “서울역 엘리베이터 위치 알려줘”, “가장 가까운 화장실 위치 알려줘”처럼 물어보세요.'));
+    } catch (e) {
+      append(msgBot(e?.message || '잠시 오류가 발생했어요.'));
+      setLoading(false);
+    }
+  };
+
+  // FlatList용 데이터(최신 메시지가 위에 오도록 역순) + keyExtractor
+  const data = [...messages].reverse();
+
+  return (
+    <SafeAreaView style={s.root} edges={['bottom']}>
+      <KeyboardAvoidingView
+        style={s.root}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        keyboardVerticalOffset={headerHeight} // 스택 헤더 보정(안드 포함)
+      >
+        <View style={s.chatArea}>
+          {/* inverted FlatList: 채팅에서 가장 안정적 */}
+          <AnimatedFlatList
+            ref={listRef}
+            data={data}
+            inverted
+            keyExtractor={(m) => m.id}
+            renderItem={({ item }) =>
+              item.type === 'map'
+                ? <MapCard payload={item.payload} />
+                : <Bubble author={item.author} text={item.text} />
+            }
+            contentContainerStyle={[
+              s.listContent,
+              { paddingBottom: 8, paddingTop: 12 },
+            ]}
+            onContentSizeChange={scrollToEnd}
+            keyboardShouldPersistTaps="handled"
+          />
+
+          {/* 하단 입력바: 절대배치 아님! → 키보드가 올라오면 KeyboardAvoidingView가 자동으로 위로 밀어줌 */}
+          <View style={[s.inputBar, { paddingBottom: Math.max(insets.bottom, 8) }]}>
+            <TextInput
+              style={s.input}
+              value={text}
+              onChangeText={setText}
+              placeholder="메시지를 입력하세요"
+              returnKeyType="send"
+              onSubmitEditing={onSend}
+              blurOnSubmit={false}
+            />
+            <TouchableOpacity style={s.sendBtn} onPress={onSend}>
+              <Text style={s.sendBtnText}>보내기</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+/* --- 프리젠테이션 --- */
+function Bubble({ author, text }) {
+  const isUser = author === USER;
+  return (
+    <View style={[s.row, isUser ? s.rowRight : s.rowLeft]}>
+      <Avatar isUser={isUser} />
+      <View style={[s.bubble, isUser ? s.userBubble : s.botBubble]}>
+        <Text style={s.bubbleText}>{text}</Text>
+      </View>
+    </View>
+  );
+}
+function Avatar({ isUser }) {
+  const source = isUser ? USER_AVATAR : BOT_AVATAR;
+  if (source) return <Image source={source} style={s.avatar} />;
+  return <View style={[s.avatar, { backgroundColor: isUser ? '#CCE5FF' : '#E6FFFA' }]} />;
+}
+function MapCard({ payload }) {
+  return (
+    <View style={s.mapCard}>
+      <View style={s.mapPh}><Text style={{ fontWeight: '700' }}>맵</Text></View>
+      <Text style={s.mapDesc}>{payload?.desc}</Text>
+    </View>
+  );
+}
+
+/* --- 모델/유틸 --- */
+let _id = 0;
+const uid = () => String(++_id);
+const msgUser = t => ({ id: uid(), author: USER, type: 'text', text: t });
+const msgBot = t => ({ id: uid(), author: BOT, type: 'text', text: t });
+const msgMapCard = p => ({ id: uid(), author: BOT, type: 'map', payload: p });
+const extractStationName = q => (q.match(/([가-힣A-Za-z0-9]+)\s*역/)?.[1] ?? null);
+
+// 성능 좋은 기본 FlatList (애니메이션 옵션 제거해도 됨)
+import { FlatList as AnimatedFlatList } from 'react-native';
+
+/* --- 스타일 --- */
+const s = StyleSheet.create({
+  root: { flex: 1, backgroundColor: '#FFF' },
+  chatArea: { flex: 1 },
+
+  listContent: {
+    paddingHorizontal: 16,
+  },
+
+  row: { flexDirection: 'row', alignItems: 'flex-end', gap: 8, marginVertical: 2 },
+  rowLeft: { justifyContent: 'flex-start' },
+  rowRight: { justifyContent: 'flex-end' },
+
+  avatar: { width: 28, height: 28, borderRadius: 14, backgroundColor: '#E6FFFA' },
+
+  bubble: { maxWidth: '76%', paddingHorizontal: 12, paddingVertical: 10, borderRadius: 14 },
+  botBubble: { backgroundColor: '#F1F5F9', borderTopLeftRadius: 4 },
+  userBubble: { backgroundColor: '#DFF7F7', borderTopRightRadius: 4 },
+  bubbleText: { fontSize: 15, lineHeight: 21, color: '#17171B' },
+
+  mapCard: {
+    alignSelf: 'flex-start',
+    marginLeft: 36,
+    backgroundColor: '#F6FAFB',
+    borderRadius: 14,
+    padding: 12, gap: 10,
+    borderWidth: 1, borderColor: '#EDF2F7',
+  },
+  mapPh: { width: 220, height: 140, borderRadius: 10, backgroundColor: '#E9EEF3', alignItems: 'center', justifyContent: 'center' },
+  mapDesc: { marginTop: 6, color: '#333', lineHeight: 20 },
+
+  inputBar: {
+    flexDirection: 'row',
+    paddingHorizontal: 10,
+    paddingTop: 10,
+    gap: 8,
+    borderTopWidth: 1,
+    borderTopColor: '#EFEFEF',
+    backgroundColor: '#FFF',
+  },
+  input: { flex: 1, backgroundColor: '#F7F7F9', borderRadius: 12, paddingHorizontal: 12, paddingVertical: 10 },
+  sendBtn: { backgroundColor: '#14CAC9', paddingHorizontal: 14, borderRadius: 12, alignItems: 'center', justifyContent: 'center' },
+  sendBtnText: { color: '#fff', fontWeight: '700' },
+});

--- a/src/screens/main/MainScreen.js
+++ b/src/screens/main/MainScreen.js
@@ -1,8 +1,7 @@
+// src/screens/main/MainScreen.js
 import React from 'react';
-// ✨ 1. StyleSheet와 반응형 유틸리티 import는 이제 필요 없습니다.
 import { View, SafeAreaView, Text, Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-// ✨ 2. 새로 만드신 mainStyles.js 파일을 import 합니다.
 import { mainStyles } from '../../styles/mainStyles';
 import CustomButton from '../../components/CustomButton';
 import { auth } from '../../config/firebaseConfig';
@@ -10,29 +9,50 @@ import { auth } from '../../config/firebaseConfig';
 const MainScreen = () => {
   const navigation = useNavigation();
 
+  const goTab = (name) => {
+    // 같은 TabNavigator 안이므로 바로 이름으로 이동
+    navigation.navigate(name);
+    // 만약 이 화면이 탭 바깥에서 렌더링된다면 아래 주석처럼 사용
+    // navigation.navigate('Tabs', { screen: name });
+  };
+
   const handleFeaturePress = (featureName) => {
     Alert.alert('알림', `${featureName} 기능은 현재 준비 중입니다.`);
   };
 
+  const handleChatbotPress = () => {
+    if (auth.currentUser) {
+      goTab('챗봇');
+    } else {
+      Alert.alert(
+        '로그인 필요',
+        '챗봇은 로그인 후 이용할 수 있습니다.\n로그인 화면으로 이동할까요?',
+        [
+          { text: '취소', style: 'cancel' },
+          { text: '확인', onPress: () => navigation.navigate('Welcome') },
+        ]
+      );
+    }
+  };
+
   return (
-    // ✨ 3. mainStyles를 사용하도록 적용합니다.
     <SafeAreaView style={mainStyles.container}>
       <View style={mainStyles.header}>
         <Text style={mainStyles.greetingText}>
           {auth.currentUser?.email}님,{"\n"}환영합니다!
         </Text>
       </View>
-      
+
       <View style={mainStyles.buttonContainer}>
         <CustomButton
           type="feature"
           title="가까운 역 안내"
-          onPress={() => navigation.navigate('안내')}
+          onPress={() => goTab('가까운 역')}
         />
         <CustomButton
           type="feature"
           title="원하는 역 검색"
-          onPress={() => navigation.navigate('검색')}
+          onPress={() => goTab('검색')}
         />
         <CustomButton
           type="outline"
@@ -42,14 +62,11 @@ const MainScreen = () => {
         <CustomButton
           type="outline"
           title="챗봇"
-          onPress={() => handleFeaturePress('챗봇')}
+          onPress={handleChatbotPress}
         />
       </View>
     </SafeAreaView>
   );
 };
 
-// ✨ 4. 파일 내부에 있던 스타일 정의를 모두 삭제하여 코드를 깔끔하게 정리했습니다.
-
 export default MainScreen;
-

--- a/src/screens/nearbystation/NearbyStationsScreen.js
+++ b/src/screens/nearbystation/NearbyStationsScreen.js
@@ -5,61 +5,60 @@ import {
   StyleSheet,
   FlatList,
   ActivityIndicator,
+  TouchableOpacity,            // ✅ 추가
 } from 'react-native';
+import { useNavigation } from '@react-navigation/native'; // ✅ 추가
 import * as Location from 'expo-location';
 import stationJson from '../../assets/metro-data/metro/station/data-metro-station-1.0.0.json';
 import lineJson from '../../assets/metro-data/metro/line/data-metro-line-1.0.0.json';
 
-// stationJson 파일 안의 실제 데이터 배열을 가져옵니다.
+// 실제 데이터 배열
 const stationData = stationJson.DATA;
-// ✨ lineJson 파일 안의 실제 데이터 배열을 가져옵니다.
 const lineData = lineJson.DATA;
 
-// 두 지점 사이의 거리를 계산하는 함수
+// 거리(km)
 function getDistance(lat1, lon1, lat2, lon2) {
-  const R = 6371; // 지구의 반지름 (km)
+  const R = 6371;
   const dLat = (lat2 - lat1) * (Math.PI / 180);
   const dLon = (lon2 - lon1) * (Math.PI / 180);
   const a =
-    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.sin(dLat / 2) ** 2 +
     Math.cos(lat1 * (Math.PI / 180)) *
       Math.cos(lat2 * (Math.PI / 180)) *
-      Math.sin(dLon / 2) *
-      Math.sin(dLon / 2);
+      Math.sin(dLon / 2) ** 2;
   const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
   return R * c;
 }
 
-// ✨ 새로운 line.json 데이터 구조에 맞춰 호선 색상을 찾는 함수
+// 호선 → 색상
 function getLineColor(lineNum) {
-  // lineData 배열에서 line 키 값이 일치하는 항목을 찾습니다.
-  const lineInfo = lineData.find(l => l.line === lineNum);
-  // 찾은 항목의 'color' 키를 반환하거나, 없으면 기본 회색을 반환합니다.
+  const lineInfo = lineData.find((l) => l.line === lineNum);
   return lineInfo ? lineInfo.color : '#666666';
 }
 
 const NearbyStationsScreen = () => {
+  const navigation = useNavigation(); // ✅ 추가
   const [nearbyStations, setNearbyStations] = useState([]);
   const [errorMsg, setErrorMsg] = useState(null);
 
   useEffect(() => {
     (async () => {
-      let { status } = await Location.requestForegroundPermissionsAsync();
+      const { status } = await Location.requestForegroundPermissionsAsync();
       if (status !== 'granted') {
         setErrorMsg('위치 정보 접근 권한이 거부되었습니다.');
         return;
       }
 
-      let currentLocation = await Location.getCurrentPositionAsync({});
+      const currentLocation = await Location.getCurrentPositionAsync({});
 
-      const stationsWithTransferInfo = stationData.map(station => {
+      const stationsWithTransferInfo = stationData.map((station) => {
         const isTransfer = stationData.some(
-          s => s.name === station.name && s.line !== station.line
+          (s) => s.name === station.name && s.line !== station.line
         );
         return { ...station, isTransfer };
       });
-      
-      const stationsWithDistance = stationsWithTransferInfo.map(station => ({
+
+      const stationsWithDistance = stationsWithTransferInfo.map((station) => ({
         ...station,
         distance: getDistance(
           currentLocation.coords.latitude,
@@ -75,7 +74,11 @@ const NearbyStationsScreen = () => {
   }, []);
 
   if (errorMsg) {
-    return <View style={styles.container}><Text>{errorMsg}</Text></View>;
+    return (
+      <View style={styles.container}>
+        <Text>{errorMsg}</Text>
+      </View>
+    );
   }
 
   if (nearbyStations.length === 0) {
@@ -94,16 +97,42 @@ const NearbyStationsScreen = () => {
         data={nearbyStations}
         keyExtractor={(item, index) => `${item.name}-${item.line}-${index}`}
         renderItem={({ item }) => (
-          <View style={styles.stationItem}>
-            <View style={[styles.lineCircle, { backgroundColor: getLineColor(item.line) }]}>
-              <Text style={styles.lineText}>{item.line.replace('호선', '')}</Text>
+          <TouchableOpacity
+            activeOpacity={0.85}
+            style={styles.stationItem}
+            onPress={() => {
+              // ✅ 부모 스택(RootStack)에 등록된 '시설'로 이동
+              const rootNav = navigation.getParent?.() || navigation;
+              rootNav.navigate('시설', {
+                stationName: item.name,
+                line: item.line,
+              });
+            }}
+          >
+            <View
+              style={[
+                styles.lineCircle,
+                { backgroundColor: getLineColor(item.line) },
+              ]}
+            >
+              <Text style={styles.lineText}>
+                {item.line.replace('호선', '')}
+              </Text>
             </View>
+
             <View style={styles.stationInfo}>
-                <Text style={styles.stationName}>{item.name}</Text>
-                {item.isTransfer && <View style={styles.transferBadge}><Text style={styles.transferText}>환승</Text></View>}
+              <Text style={styles.stationName}>{item.name}</Text>
+              {item.isTransfer && (
+                <View style={styles.transferBadge}>
+                  <Text style={styles.transferText}>환승</Text>
+                </View>
+              )}
             </View>
-            <Text style={styles.distanceText}>{item.distance.toFixed(1)}km</Text>
-          </View>
+
+            <Text style={styles.distanceText}>
+              {item.distance.toFixed(1)}km
+            </Text>
+          </TouchableOpacity>
         )}
       />
     </View>
@@ -111,84 +140,35 @@ const NearbyStationsScreen = () => {
 };
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#f5f5f5',
-    paddingTop: 50,
-  },
-  centered: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  loadingText: {
-    marginTop: 10,
-    fontSize: 16,
-    color: '#333',
-  },
+  container: { flex: 1, backgroundColor: '#f5f5f5', paddingTop: 50 },
+  centered: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  loadingText: { marginTop: 10, fontSize: 16, color: '#333' },
   title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    textAlign: 'center',
-    marginBottom: 20,
-    color: '#111',
+    fontSize: 24, fontWeight: 'bold', textAlign: 'center',
+    marginBottom: 20, color: '#111',
   },
   stationItem: {
     backgroundColor: '#ffffff',
-    paddingVertical: 15,
-    paddingHorizontal: 20,
-    marginVertical: 6,
-    marginHorizontal: 16,
-    borderRadius: 30,
-    flexDirection: 'row',
-    alignItems: 'center',
-    elevation: 2,
-    shadowColor: '#000',
+    paddingVertical: 15, paddingHorizontal: 20,
+    marginVertical: 6, marginHorizontal: 16,
+    borderRadius: 30, flexDirection: 'row', alignItems: 'center',
+    elevation: 2, shadowColor: '#000',
     shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.2,
-    shadowRadius: 1.41,
+    shadowOpacity: 0.2, shadowRadius: 1.41,
   },
   lineCircle: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginRight: 15,
+    width: 40, height: 40, borderRadius: 20,
+    justifyContent: 'center', alignItems: 'center', marginRight: 15,
   },
-  lineText: {
-    color: '#ffffff',
-    fontWeight: 'bold',
-    fontSize: 16,
-  },
-  stationInfo: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  stationName: {
-    fontSize: 18,
-    fontWeight: '500',
-    color: '#333',
-  },
-  distanceText: {
-    fontSize: 16,
-    fontWeight: 'bold',
-    color: '#007bff',
-  },
+  lineText: { color: '#ffffff', fontWeight: 'bold', fontSize: 16 },
+  stationInfo: { flex: 1, flexDirection: 'row', alignItems: 'center' },
+  stationName: { fontSize: 18, fontWeight: '500', color: '#333' },
+  distanceText: { fontSize: 16, fontWeight: 'bold', color: '#007bff' },
   transferBadge: {
-    backgroundColor: '#f0f0f0',
-    borderRadius: 8,
-    paddingHorizontal: 6,
-    paddingVertical: 2,
-    marginLeft: 8,
+    backgroundColor: '#f0f0f0', borderRadius: 8,
+    paddingHorizontal: 6, paddingVertical: 2, marginLeft: 8,
   },
-  transferText: {
-    color: '#555',
-    fontSize: 12,
-    fontWeight: 'bold',
-  },
+  transferText: { color: '#555', fontSize: 12, fontWeight: 'bold' },
 });
 
 export default NearbyStationsScreen;
-

--- a/src/screens/searchstation/SearchStationScreen.js
+++ b/src/screens/searchstation/SearchStationScreen.js
@@ -1,3 +1,4 @@
+// src/screens/searchstation/SearchStationScreen.js
 import React, { useState, useMemo } from 'react';
 import {
   View,
@@ -6,76 +7,56 @@ import {
   TextInput,
   FlatList,
   SafeAreaView,
+  TouchableOpacity, // ✅ 추가
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native'; // ✅ 추가
 import stationJson from '../../assets/metro-data/metro/station/data-metro-station-1.0.0.json';
 import lineJson from '../../assets/metro-data/metro/line/data-metro-line-1.0.0.json';
 
-
-// 데이터 파일에서 실제 배열을 가져옵니다.
+// 데이터
 const allStations = stationJson.DATA;
 const lineData = lineJson.DATA;
 
-
-// 호선 색상을 찾는 헬퍼 함수
+// 호선 → 색상
 function getLineColor(lineNum) {
-  const lineInfo = lineData.find(l => l.line === lineNum);
+  const lineInfo = lineData.find((l) => l.line === lineNum);
   return lineInfo ? lineInfo.color : '#666666';
 }
 
-
-// 메인 컴포넌트
 const SearchStationScreen = () => {
-  // 사용자가 입력한 검색어를 저장할 state
+  const navigation = useNavigation(); // ✅ 추가
   const [searchQuery, setSearchQuery] = useState('');
 
-
-  // 검색 결과를 저장할 state
   const searchResults = useMemo(() => {
-    // 검색어가 없으면 아무것도 보여주지 않습니다.
-    if (!searchQuery.trim()) {
-      return [];
-    }
+    const q = searchQuery.trim();
+    if (!q) return [];
 
-
-    // 1. 검색어와 일치하는 모든 역을 찾습니다.
-    const matchingStations = allStations.filter(station =>
-      station.name.startsWith(searchQuery)
+    const matchingStations = allStations.filter((station) =>
+      station.name.startsWith(q)
     );
 
-
-    // 2. 환승역 데이터를 합칩니다.
-    // 예: '노원'역에 대한 { name: '노원', lines: ['4호선', '7호선'] } 형태의 객체를 만듭니다.
     const stationMap = new Map();
-
-
-    matchingStations.forEach(station => {
+    matchingStations.forEach((station) => {
       if (stationMap.has(station.name)) {
-        // 이미 맵에 역 이름이 있으면, 호선 정보만 추가합니다.
-        const existingStation = stationMap.get(station.name);
-        existingStation.lines.push(station.line);
+        stationMap.get(station.name).lines.push(station.line);
       } else {
-        // 맵에 새로운 역이면, 역 정보와 함께 호선 배열을 추가합니다.
-        stationMap.set(station.name, {
-          name: station.name,
-          lines: [station.line],
-        });
+        stationMap.set(station.name, { name: station.name, lines: [station.line] });
       }
     });
-   
-    // 맵의 값들을 배열로 변환하여 최종 결과로 사용합니다.
-    return Array.from(stationMap.values());
-  }, [searchQuery]); // searchQuery가 변경될 때만 이 계산을 다시 실행합니다.
 
+    return Array.from(stationMap.values());
+  }, [searchQuery]);
 
   return (
     <SafeAreaView style={styles.container}>
-      {/* 뒤로가기 버튼과 타이틀 (실제 구현 시 네비게이션 헤더 사용) */}
+      {/* 헤더 (탭 헤더를 쓰는 경우 생략해도 됨) */}
       <View style={styles.header}>
-        <Ionicons name="arrow-back" size={24} color="black" />
+        <TouchableOpacity onPress={() => navigation.goBack()} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+          <Ionicons name="arrow-back" size={24} color="black" />
+        </TouchableOpacity>
         <Text style={styles.headerTitle}>원하는 역 검색</Text>
       </View>
-
 
       {/* 검색창 */}
       <View style={styles.searchContainer}>
@@ -84,134 +65,96 @@ const SearchStationScreen = () => {
           style={styles.input}
           placeholder="역 이름을 입력하세요"
           value={searchQuery}
-          onChangeText={setSearchQuery} // 입력할 때마다 searchQuery state 업데이트
-          autoFocus={true} // 화면이 뜨면 바로 키보드 나타남
+          onChangeText={setSearchQuery}
+          autoFocus={true}
+          returnKeyType="search"
         />
         {searchQuery.length > 0 && (
-            <View style={styles.searchButton}>
-                <Text style={styles.searchButtonText}>검색</Text>
-            </View>
+          <View style={styles.searchButton}>
+            <Text style={styles.searchButtonText}>검색</Text>
+          </View>
         )}
       </View>
 
-
-      {/* 검색 결과 목록 */}
+      {/* 검색 결과 */}
       <FlatList
         data={searchResults}
-        keyExtractor={item => item.name}
-        renderItem={({ item }) => (
-          <View style={styles.resultItem}>
-            <Ionicons name="location-outline" size={24} color="black" style={styles.locationIcon}/>
-            <Text style={styles.stationName}>{item.name}</Text>
-            <View style={styles.lineContainer}>
-              {item.lines.map(line => (
-                <View
-                  key={line}
-                  style={[styles.lineCircle, { backgroundColor: getLineColor(line) }]}
-                >
-                  <Text style={styles.lineText}>{line.replace('호선', '')}</Text>
-                </View>
-              ))}
-            </View>
-          </View>
-        )}
-        // 검색 결과가 없을 때 보여줄 메시지 (선택사항)
+        keyExtractor={(item) => item.name}
+        keyboardShouldPersistTaps="handled"
+        renderItem={({ item }) => {
+          const firstLine = item.lines[0];
+          return (
+            <TouchableOpacity
+              activeOpacity={0.85}
+              style={styles.resultItem}
+              onPress={() => {
+                // ✅ 부모 스택(RootStack)에 등록된 '시설'로 이동
+                const rootNav = navigation.getParent?.() || navigation;
+                rootNav.navigate('시설', { stationName: item.name, line: firstLine });
+              }}
+            >
+              <Ionicons
+                name="location-outline"
+                size={24}
+                color="black"
+                style={styles.locationIcon}
+              />
+              <Text style={styles.stationName}>{item.name}</Text>
+              <View style={styles.lineContainer}>
+                {item.lines.map((line) => (
+                  <View
+                    key={line}
+                    style={[styles.lineCircle, { backgroundColor: getLineColor(line) }]}
+                  >
+                    <Text style={styles.lineText}>{line.replace('호선', '')}</Text>
+                  </View>
+                ))}
+              </View>
+            </TouchableOpacity>
+          );
+        }}
         ListEmptyComponent={
-            searchQuery.length > 0 ? (
-                <Text style={styles.emptyText}>검색 결과가 없습니다.</Text>
-            ) : null
+          searchQuery.length > 0 ? (
+            <Text style={styles.emptyText}>검색 결과가 없습니다.</Text>
+          ) : null
         }
       />
     </SafeAreaView>
   );
 };
 
-
 // 스타일
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-  },
+  container: { flex: 1, backgroundColor: '#fff' },
   header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: '#e5e5e5',
+    flexDirection: 'row', alignItems: 'center',
+    paddingHorizontal: 16, paddingVertical: 12,
+    borderBottomWidth: 1, borderBottomColor: '#e5e5e5',
   },
-  headerTitle: {
-    fontSize: 18,
-    fontWeight: '600',
-    marginLeft: 16,
-  },
+  headerTitle: { fontSize: 18, fontWeight: '600', marginLeft: 16 },
   searchContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#f0f0f0',
-    borderRadius: 20,
-    margin: 16,
-    paddingHorizontal: 12,
+    flexDirection: 'row', alignItems: 'center',
+    backgroundColor: '#f0f0f0', borderRadius: 20,
+    margin: 16, paddingHorizontal: 12,
   },
-  searchIcon: {
-    marginRight: 8,
-  },
-  input: {
-    flex: 1,
-    height: 40,
-    fontSize: 16,
-  },
-  searchButton: {
-    backgroundColor: '#00B8D4',
-    borderRadius: 15,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-  },
-  searchButtonText: {
-      color: 'white',
-      fontWeight: 'bold',
-  },
+  searchIcon: { marginRight: 8 },
+  input: { flex: 1, height: 40, fontSize: 16 },
+  searchButton: { backgroundColor: '#00B8D4', borderRadius: 15, paddingHorizontal: 12, paddingVertical: 6 },
+  searchButtonText: { color: 'white', fontWeight: 'bold' },
   resultItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: '#f0f0f0',
+    flexDirection: 'row', alignItems: 'center',
+    paddingHorizontal: 16, paddingVertical: 12,
+    borderBottomWidth: 1, borderBottomColor: '#f0f0f0',
   },
-  locationIcon: {
-      marginRight: 12,
-  },
-  stationName: {
-    flex: 1,
-    fontSize: 16,
-  },
-  lineContainer: {
-    flexDirection: 'row',
-  },
+  locationIcon: { marginRight: 12 },
+  stationName: { flex: 1, fontSize: 16 },
+  lineContainer: { flexDirection: 'row' },
   lineCircle: {
-    width: 24,
-    height: 24,
-    borderRadius: 12,
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginLeft: 8,
+    width: 24, height: 24, borderRadius: 12,
+    justifyContent: 'center', alignItems: 'center', marginLeft: 8,
   },
-  lineText: {
-    color: 'white',
-    fontSize: 12,
-    fontWeight: 'bold',
-  },
-  emptyText: {
-      textAlign: 'center',
-      marginTop: 20,
-      color: 'gray',
-  }
+  lineText: { color: 'white', fontSize: 12, fontWeight: 'bold' },
+  emptyText: { textAlign: 'center', marginTop: 20, color: 'gray' },
 });
 
-
 export default SearchStationScreen;
-
-
-

--- a/src/screens/station/FacilitiesSection.js
+++ b/src/screens/station/FacilitiesSection.js
@@ -1,0 +1,155 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+
+// 시설 키 상수
+export const FAC = {
+  ESCALATOR: 'escalator',
+  ELEVATOR: 'elevator',
+  ACCESSIBLE_TOILET: 'accessible_toilet',
+  WHEELCHAIR_LIFT: 'wheelchair_lift',
+  WIDE_GATE: 'wide_gate',            // ✅ 추천 추가
+  PRIORITY_SEAT: 'priority_seat',    // (열차 내부 → 추후 분리 권장)
+  NURSING: 'nursing_room',
+  LOCKER: 'locker',
+  AUDIO_GUIDE: 'audio_beacon',
+};
+
+const moveFacilities = [
+  { key: FAC.ESCALATOR, label: '에스컬레이터\n위치' },
+  { key: FAC.ELEVATOR, label: '엘리베이터\n위치' },
+  { key: FAC.ACCESSIBLE_TOILET, label: '장애인\n화장실 위치' },
+  { key: FAC.WHEELCHAIR_LIFT, label: '휠체어\n리프트 위치' },
+  { key: FAC.WIDE_GATE, label: '광폭 개찰구\n위치' },
+  // { key: FAC.PRIORITY_SEAT, label: '노약자석\n위치' },
+];
+
+const lifeFacilities = [
+  { key: FAC.NURSING, label: '수유실\n위치' },
+  { key: FAC.LOCKER, label: '물품보관함\n위치' },
+  { key: FAC.AUDIO_GUIDE, label: '음성유도기\n위치' },
+];
+
+export default function FacilitiesSection({
+  stationName,
+  fetchLocation,          // (name, key) => Promise<string>
+  focusKey = null,        // ✅ 처음 선택할 키(요약화면에서 넘겨줌)
+  showResult = true,      // ✅ 결과 박스 표시 여부
+  onSelect,               // 선택 콜백(optional)
+}) {
+  const [selected, setSelected] = useState(null);
+  const [result, setResult] = useState('');
+
+  useEffect(() => {
+    if (focusKey) handlePress(focusKey); // 처음에 자동 선택/조회
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [focusKey, stationName]);
+
+  const handlePress = async (key) => {
+    setSelected(key);
+    onSelect?.(key);
+    try {
+      const text = await (fetchLocation
+        ? fetchLocation(stationName, key)
+        : Promise.resolve(`"${stationName}" 역의 ${labelFor(key)}는 개찰구 근처에 있어요.`));
+      setResult(text);
+    } catch (e) {
+      setResult(e?.message || '위치를 불러오지 못했습니다.');
+    }
+  };
+
+  return (
+    <View style={{ gap: 16 }}>
+      <Category title="이동시설">
+        <TileGrid items={moveFacilities} selected={selected} onPress={handlePress} />
+      </Category>
+
+      <Category title="편의시설">
+        <TileGrid items={lifeFacilities} selected={selected} onPress={handlePress} />
+      </Category>
+
+      {showResult && !!result && (
+        <View style={s.resultBox}><Text style={s.resultText}>{result}</Text></View>
+      )}
+    </View>
+  );
+}
+
+function Category({ title, children }) {
+  return (
+    <View style={{ gap: 10 }}>
+      <Text style={s.sectionTitle}>{title}</Text>
+      <View style={s.sectionBox}>{children}</View>
+    </View>
+  );
+}
+
+function TileGrid({ items, selected, onPress }) {
+  return (
+    <View style={s.grid}>
+      {items.map((it) => {
+        const active = selected === it.key;
+        return (
+          <TouchableOpacity
+            key={it.key}
+            style={[s.tile, active ? s.tileActive : s.tileIdle]}
+            onPress={() => onPress(it.key)}
+            activeOpacity={0.8}
+          >
+            <Text style={s.tileIcon}>{emoji(it.key)}</Text>
+            <Text style={[s.tileLabel, active ? s.labelActive : s.labelIdle]}>{it.label}</Text>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+}
+
+/* 유틸 */
+const labelFor = (key) =>
+  ({
+    [FAC.ESCALATOR]: '에스컬레이터',
+    [FAC.ELEVATOR]: '엘리베이터',
+    [FAC.ACCESSIBLE_TOILET]: '장애인 화장실',
+    [FAC.WHEELCHAIR_LIFT]: '휠체어 리프트',
+    [FAC.WIDE_GATE]: '광폭 개찰구',
+    [FAC.NURSING]: '수유실',
+    [FAC.LOCKER]: '물품보관함',
+    [FAC.AUDIO_GUIDE]: '음성유도기',
+    [FAC.PRIORITY_SEAT]: '노약자석',
+  }[key] || key);
+
+const emoji = (key) =>
+  ({
+    [FAC.ESCALATOR]: '↗️',
+    [FAC.ELEVATOR]: '🛗',
+    [FAC.ACCESSIBLE_TOILET]: '🚻',
+    [FAC.WHEELCHAIR_LIFT]: '♿',
+    [FAC.WIDE_GATE]: '🚪',
+    [FAC.NURSING]: '🍼',
+    [FAC.LOCKER]: '🧳',
+    [FAC.AUDIO_GUIDE]: '📢',
+    [FAC.PRIORITY_SEAT]: '💺',
+  }[key] || '⬜️');
+
+/* 스타일 */
+const s = StyleSheet.create({
+  sectionTitle: { fontSize: 18, fontWeight: '700', color: '#222' },
+  sectionBox: { backgroundColor: '#EAF1F4', borderRadius: 16, padding: 12 },
+  grid: { flexDirection: 'row', flexWrap: 'wrap', gap: 12 },
+  tile: {
+    width: '30%', aspectRatio: 1, borderRadius: 18,
+    alignItems: 'center', justifyContent: 'center',
+    shadowColor: '#000', shadowOpacity: 0.08, shadowRadius: 6, elevation: 2,
+  },
+  tileIdle: { backgroundColor: '#14CAC9' },
+  tileActive: { backgroundColor: '#fff', borderWidth: 2, borderColor: '#14CAC9' },
+  tileIcon: { fontSize: 28, marginBottom: 6 },
+  tileLabel: { textAlign: 'center', lineHeight: 18, fontWeight: '700' },
+  labelIdle: { color: '#fff' },
+  labelActive: { color: '#14CAC9' },
+  resultBox: {
+    backgroundColor: '#F6FAFB', borderRadius: 12, padding: 12,
+    borderColor: '#E3EDF3', borderWidth: 1,
+  },
+  resultText: { color: '#333' },
+});

--- a/src/screens/station/StationDetailScreen.js
+++ b/src/screens/station/StationDetailScreen.js
@@ -1,0 +1,201 @@
+// src/screens/station/StationDetailScreen.js
+import React, { useMemo, useLayoutEffect, useState } from 'react';
+import {
+  View, Text, StyleSheet, ScrollView, TouchableOpacity, Alert,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import stationJson from '../../assets/metro-data/metro/station/data-metro-station-1.0.0.json';
+import lineJson from '../../assets/metro-data/metro/line/data-metro-line-1.0.0.json';
+
+// 데이터 배열
+const allStations = stationJson.DATA;
+const lineData = lineJson.DATA;
+
+// 호선 → 색상
+function getLineColor(lineNum) {
+  const lineInfo = lineData.find((l) => l.line === lineNum);
+  return lineInfo ? lineInfo.color : '#666666';
+}
+
+export default function StationDetailScreen({ route, navigation }) {
+  const { stationName } = route.params ?? {};
+
+  // 헤더 우측: 한눈에 보기(요약 화면으로 이동)
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      title: `${stationName}역`,
+      headerRight: () => (
+        <TouchableOpacity
+          onPress={() => navigation.navigate('시설', { stationName, line: firstLine })}
+          style={s.headerPill}
+        >
+          <Text style={s.headerPillText}>한눈에 보기</Text>
+        </TouchableOpacity>
+      ),
+    });
+  }, [navigation, stationName]);
+
+  // 이 역이 가진 모든 호선 카드 생성 (스크린샷처럼 카드 2장 이상일 수 있음)
+  const lines = useMemo(() => {
+    const matches = allStations.filter((st) => st.name === stationName);
+    const uniq = Array.from(new Set(matches.map((m) => m.line)));
+    return uniq.length ? uniq : ['-'];
+  }, [stationName]);
+
+  const firstLine = lines[0];
+
+  return (
+    <ScrollView style={s.container} contentContainerStyle={s.content}>
+      {lines.map((line) => (
+        <StationCard
+          key={line}
+          stationName={stationName}
+          line={line}
+          distanceKm={1.1} // TODO: 실제 거리 넣고 싶으면 route.params에서 넘겨주기
+          phone={'02 - XXXX - XXXX'} // TODO: 데이터 붙이면 교체
+        />
+      ))}
+    </ScrollView>
+  );
+}
+
+/* ===== 카드 ===== */
+function StationCard({ stationName, line, phone, distanceKm }) {
+  const [fav, setFav] = useState(false);
+
+  return (
+    <View style={s.card}>
+      {/* 헤더: 호선 pill + 역명 + 즐겨찾기 */}
+      <View style={s.cardHeader}>
+        <View style={[s.lineBadge, { borderColor: getLineColor(line) }]}>
+          <Text style={[s.lineBadgeText, { color: getLineColor(line) }]}>
+            {line}
+          </Text>
+        </View>
+        <Text style={s.cardTitle}>{stationName}</Text>
+        <TouchableOpacity onPress={() => setFav((v) => !v)} style={s.starBtn}>
+          <Ionicons name={fav ? 'star' : 'star-outline'} size={22} color="#666" />
+        </TouchableOpacity>
+      </View>
+
+      {/* 전화 */}
+      <View style={s.row}>
+        <Ionicons name="call-outline" size={18} color="#333" />
+        <Text style={s.phoneText}>{phone}</Text>
+      </View>
+
+      {/* 사용 가능 시설 */}
+      <View style={s.rowWrap}>
+        <Ionicons name="checkmark-circle-outline" size={20} color="#14CAC9" />
+        <View style={s.chipRow}>
+          <Chip label="엘리베이터" />
+          <Chip label="에스컬레이터" />
+          <Chip label="수유실" />
+        </View>
+      </View>
+
+      {/* 준비/미설치 등 */}
+      <View style={s.rowWrap}>
+        <Ionicons name="close-circle-outline" size={20} color="#999" />
+        <View style={s.chipRow}>
+          <Chip label="휠체어 충전기" type="ghost" />
+        </View>
+      </View>
+
+      {/* 하단: 거리 / 자세히 보기(더 깊은 상세) */}
+      <View style={s.footerRow}>
+        <Text style={s.distance}>{distanceKm?.toFixed?.(1)}km</Text>
+        <TouchableOpacity
+          style={s.more}
+          onPress={() => Alert.alert('자세히 보기', '여기에 더 깊은 상세를 연결하세요.')}
+        >
+          <Text style={s.moreText}>자세히 보기</Text>
+          <Ionicons name="arrow-forward-circle-outline" size={18} color="#555" />
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+/* ===== 프리젠테이션 조각 ===== */
+function Chip({ label, type = 'filled' }) {
+  if (type === 'ghost') {
+    return (
+      <View style={s.chipGhost}>
+        <Text style={s.chipGhostText}>{label}</Text>
+      </View>
+    );
+  }
+  return (
+    <View style={s.chip}>
+      <Text style={s.chipText}>{label}</Text>
+    </View>
+  );
+}
+
+/* ===== 스타일 ===== */
+const s = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  content: { padding: 16, paddingBottom: 24 },
+
+  headerPill: {
+    borderWidth: 1, borderColor: '#0BA7A6',
+    paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999, marginRight: 8,
+  },
+  headerPillText: { color: '#0BA7A6', fontWeight: '700' },
+
+  card: {
+    backgroundColor: '#F3F6F8',
+    borderRadius: 18,
+    paddingVertical: 14,
+    paddingHorizontal: 14,
+    marginBottom: 16,
+  },
+  cardHeader: {
+    flexDirection: 'row', alignItems: 'center',
+  },
+  lineBadge: {
+    borderWidth: 1.5,
+    paddingHorizontal: 8, paddingVertical: 4,
+    borderRadius: 999, marginRight: 10,
+    backgroundColor: '#fff',
+  },
+  lineBadgeText: { fontSize: 13, fontWeight: '800' },
+  cardTitle: { fontSize: 18, fontWeight: '800', color: '#0F172A', flex: 1 },
+  starBtn: { padding: 6 },
+
+  row: {
+    flexDirection: 'row', alignItems: 'center',
+    marginTop: 10, gap: 8,
+    backgroundColor: '#fff', borderRadius: 12, padding: 10,
+  },
+  phoneText: { fontSize: 15, color: '#333' },
+
+  rowWrap: {
+    flexDirection: 'row', alignItems: 'center',
+    marginTop: 10, gap: 8,
+  },
+  chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+
+  chip: {
+    backgroundColor: '#14CAC9',
+    paddingHorizontal: 12, paddingVertical: 8,
+    borderRadius: 999,
+  },
+  chipText: { color: '#fff', fontWeight: '700', fontSize: 13 },
+
+  chipGhost: {
+    paddingHorizontal: 10, paddingVertical: 6,
+    borderRadius: 999, borderWidth: 1, borderColor: '#BFD9DE',
+    backgroundColor: '#fff',
+  },
+  chipGhostText: { color: '#2A3B44', fontWeight: '700', fontSize: 12 },
+
+  footerRow: {
+    marginTop: 12, flexDirection: 'row',
+    alignItems: 'center', justifyContent: 'space-between',
+  },
+  distance: { fontSize: 16, fontWeight: '800', color: '#111' },
+  more: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  moreText: { fontWeight: '700', color: '#555' },
+});

--- a/src/screens/station/StationFacilitiesScreen.js
+++ b/src/screens/station/StationFacilitiesScreen.js
@@ -1,0 +1,205 @@
+// src/screens/station/StationFacilitiesScreen.js
+import React, { useLayoutEffect, useMemo, useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, ScrollView } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import FacilitiesSection, { FAC } from './FacilitiesSection';
+import { getFacilityLocation } from '../../api/facilities';
+
+// 상세 카드에 필요한 데이터(호선/색상)
+import stationJson from '../../assets/metro-data/metro/station/data-metro-station-1.0.0.json';
+import lineJson from '../../assets/metro-data/metro/line/data-metro-line-1.0.0.json';
+const allStations = stationJson.DATA;
+const lineData = lineJson.DATA;
+const lineColor = (line) => lineData.find((l) => l.line === line)?.color ?? '#666';
+
+export default function StationFacilitiesScreen({ route, navigation }) {
+  const { stationName, line: initialLine } = route.params ?? {};
+
+  // mode=false(자세히 보기), mode=true(한눈에 보기)
+  const [overview, setOverview] = useState(false);
+  const [focusKey, setFocusKey] = useState(null);
+
+  // 헤더 오른쪽 pill: 누를 때마다 모드 전환
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      title: `${stationName}역`,
+      headerRight: () => (
+        <TouchableOpacity
+          onPress={() => setOverview((v) => !v)}
+          style={s.headerPill}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          <Text style={s.headerPillText}>{overview ? '자세히 보기' : '한눈에 보기'}</Text>
+        </TouchableOpacity>
+      ),
+    });
+  }, [navigation, stationName, overview]);
+
+  // 이 역이 속한 모든 호선(상세 카드에서 사용)
+  const lines = useMemo(() => {
+    const matches = allStations.filter((st) => st.name === stationName);
+    const uniq = Array.from(new Set(matches.map((m) => m.line)));
+    return uniq.length ? uniq : (initialLine ? [initialLine] : ['-']);
+  }, [stationName, initialLine]);
+
+  // 상세 카드에서 특정 타일을 바로 보고 싶을 때(옵션)
+  const openOverviewFocused = (key) => {
+    setFocusKey(key);
+    setOverview(true);
+  };
+
+  return (
+    <View style={s.root}>
+      {/* 모드 1: 자세히 보기(카드 리스트) */}
+      {!overview && (
+        <ScrollView style={s.container} contentContainerStyle={s.content}>
+          {lines.map((ln) => (
+            <DetailCard
+              key={ln}
+              stationName={stationName}
+              line={ln}
+              onChipPress={openOverviewFocused} // 칩 누르면 한눈에 보기로 전환(선택)
+            />
+          ))}
+        </ScrollView>
+      )}
+
+      {/* 모드 2: 한눈에 보기(그리드) */}
+      {overview && (
+        <ScrollView style={s.container} contentContainerStyle={s.content}>
+          <FacilitiesSection
+            stationName={stationName}
+            fetchLocation={getFacilityLocation}
+            focusKey={focusKey}
+            showResult
+          />
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+/* ====== 상세 카드 컴포넌트(사진2 레이아웃) ====== */
+function DetailCard({ stationName, line, onChipPress }) {
+  const color = lineColor(line);
+
+  return (
+    <View style={s.card}>
+      {/* 헤더: 호선 pill + 역명 + 즐겨찾기 */}
+      <View style={s.cardHeader}>
+        <View style={[s.lineBadge, { borderColor: color }]}>
+          <Text style={[s.lineBadgeText, { color }]}>{line}</Text>
+        </View>
+        <Text style={s.cardTitle}>{stationName}</Text>
+        <TouchableOpacity style={s.starBtn}>
+          <Ionicons name="star-outline" size={22} color="#666" />
+        </TouchableOpacity>
+      </View>
+
+      {/* 전화 */}
+      <View style={s.row}>
+        <Ionicons name="call-outline" size={18} color="#333" />
+        <Text style={s.phoneText}>02 - XXXX - XXXX</Text>
+      </View>
+
+      {/* 사용 가능 시설 칩 */}
+      <View style={s.rowWrap}>
+        <Ionicons name="checkmark-circle-outline" size={20} color="#14CAC9" />
+        <View style={s.chipRow}>
+          <Chip label="엘리베이터" onPress={() => onChipPress?.(FAC.ELEVATOR)} />
+          <Chip label="에스컬레이터" onPress={() => onChipPress?.(FAC.ESCALATOR)} />
+          <Chip label="수유실" onPress={() => onChipPress?.(FAC.NURSING)} />
+        </View>
+      </View>
+
+      {/* 미설치/준비 중 */}
+      <View style={s.rowWrap}>
+        <Ionicons name="close-circle-outline" size={20} color="#999" />
+        <View style={s.chipRow}>
+          <Chip label="휠체어 충전기" type="ghost" />
+        </View>
+      </View>
+
+      {/* 하단: 거리/자세히보기(아이콘만 유지, 네비게이션 없음) */}
+      <View style={s.footerRow}>
+        <Text style={s.distance}>1.1km</Text>
+        <View style={s.more}>
+          <Text style={s.moreText}>자세히 보기</Text>
+          <Ionicons name="arrow-forward-circle-outline" size={18} color="#555" />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function Chip({ label, type = 'filled', onPress }) {
+  const Comp = (
+    <View style={type === 'filled' ? s.chip : s.chipGhost}>
+      <Text style={type === 'filled' ? s.chipText : s.chipGhostText}>{label}</Text>
+    </View>
+  );
+  return onPress ? (
+    <TouchableOpacity onPress={onPress} activeOpacity={0.8}>
+      {Comp}
+    </TouchableOpacity>
+  ) : (
+    Comp
+  );
+}
+
+/* ====== 스타일 ====== */
+const s = StyleSheet.create({
+  root: { flex: 1, backgroundColor: '#fff' },
+  container: { flex: 1, backgroundColor: '#fff' },
+  content: { padding: 16, paddingBottom: 24 },
+
+  headerPill: {
+    borderWidth: 1, borderColor: '#0BA7A6',
+    paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999, marginRight: 8,
+  },
+  headerPillText: { color: '#0BA7A6', fontWeight: '700' },
+
+  /* 카드 */
+  card: {
+    backgroundColor: '#F3F6F8',
+    borderRadius: 18,
+    paddingVertical: 14,
+    paddingHorizontal: 14,
+    marginBottom: 16,
+  },
+  cardHeader: { flexDirection: 'row', alignItems: 'center' },
+  lineBadge: {
+    borderWidth: 1.5,
+    paddingHorizontal: 8, paddingVertical: 4,
+    borderRadius: 999, marginRight: 10,
+    backgroundColor: '#fff',
+  },
+  lineBadgeText: { fontSize: 13, fontWeight: '800' },
+  cardTitle: { fontSize: 18, fontWeight: '800', color: '#0F172A', flex: 1 },
+  starBtn: { padding: 6 },
+
+  row: {
+    flexDirection: 'row', alignItems: 'center',
+    marginTop: 10, gap: 8,
+    backgroundColor: '#fff', borderRadius: 12, padding: 10,
+  },
+  phoneText: { fontSize: 15, color: '#333' },
+
+  rowWrap: { flexDirection: 'row', alignItems: 'center', marginTop: 10, gap: 8 },
+  chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+
+  chip: { backgroundColor: '#14CAC9', paddingHorizontal: 12, paddingVertical: 8, borderRadius: 999 },
+  chipText: { color: '#fff', fontWeight: '700', fontSize: 13 },
+
+  chipGhost: {
+    paddingHorizontal: 10, paddingVertical: 6,
+    borderRadius: 999, borderWidth: 1, borderColor: '#BFD9DE',
+    backgroundColor: '#fff',
+  },
+  chipGhostText: { color: '#2A3B44', fontWeight: '700', fontSize: 12 },
+
+  footerRow: { marginTop: 12, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  distance: { fontSize: 16, fontWeight: '800', color: '#111' },
+  more: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  moreText: { fontWeight: '700', color: '#555' },
+});


### PR DESCRIPTION
챗봇 틀 잡아둠. 상세한 명령은 api 가져오면 완성
<img width="540" height="1058" alt="image" src="https://github.com/user-attachments/assets/3c7b6a75-8ae2-4ac9-a769-996b96b129eb" />

역사 클릭 > 자세히 보기 / 간단히 보기 틀 잡아둠. 상세한 정보는 api 가져오면 완성
<img width="540" height="1058" alt="image" src="https://github.com/user-attachments/assets/78d258df-2ac7-4a1c-b3a1-7b2b7b84b17d" />
<img width="540" height="1058" alt="image" src="https://github.com/user-attachments/assets/6e3be9c5-3965-4531-8048-12407423f303" />

해야하는 것: ui 최적화(공통), 원하는 역 검색 중복 제거(누리), 자세히 보기 / 간단히 보기 하단 네비게이션 탭 추가(공통), 간단히 보기 아이콘 수정(누리), api 연동(누리)
궁금한 것: 챗봇 눌렀을 때 이미지가 형광색으로 변하는 건 의도된 건지?