### PR TITLE
폰트크기조절기능생성(Feat/font size setting)

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,19 +1,17 @@
-// App.js
-import React, { useState, useEffect } from 'react';
-import { View, ActivityIndicator, Alert, Image, ScrollView, StyleSheet } from 'react-native';
-import { NavigationContainer, useNavigation, useRoute } from '@react-navigation/native';
+import React, { useEffect } from 'react';
+import { View, ActivityIndicator, Alert, Image } from 'react-native';
+import { NavigationContainer, useNavigation } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-import { onAuthStateChanged } from 'firebase/auth';
-import { auth } from './src/config/firebaseConfig';
 import { useFonts } from 'expo-font';
 import { GoogleSignin } from '@react-native-google-signin/google-signin';
 
-// 접근성 관련
-import { FontSizeProvider } from './src/contexts/FontSizeContext'; 
+// --- Context Provider 및 훅 ---
 import { AuthProvider, useAuth } from './src/contexts/AuthContext';
+import { FontSizeProvider, useFontSize } from './src/contexts/FontSizeContext'; 
+import { responsiveFontSize } from './src/utils/responsive';
 
 // --- 화면들 ---
 import WelcomeScreen from './src/screens/auth/WelcomeScreen';
@@ -39,7 +37,7 @@ const MyPageStack = createStackNavigator();
 const NearbyStack = createStackNavigator();
 const SearchStack = createStackNavigator();
 
-// --- 공통 탭 옵션 ---
+// --- 공통 탭 옵션 (기본값으로 사용) ---
 const commonTabOptions = {
   headerShown: true,
   headerTitleAlign: 'center',
@@ -47,67 +45,81 @@ const commonTabOptions = {
   headerTitleStyle: { fontFamily: 'NotoSansKR', fontWeight: '700', color: '#17171B' },
   tabBarActiveTintColor: '#17171B',
   tabBarInactiveTintColor: 'gray',
-  tabBarStyle: {
-    height: 90,
-    backgroundColor: '#F9F9F9',
-    elevation: 0,
-    shadowOpacity: 0,
-    borderTopWidth: 0,
-  },
-  tabBarLabelStyle: {
-    fontSize: 16,
-    fontFamily: 'NotoSansKR',
-    fontWeight: '700',
-    marginBottom: 5,
-  },
 };
 
-// --- 재사용할 민트색 헤더 옵션 ---
+// --- 헤더 옵션 ---
 const mintHeaderOptions = {
   headerTitleAlign: 'center',
   headerStyle: { backgroundColor: '#F9F9F9', elevation: 0, shadowOpacity: 0 },
   headerTitleStyle: { fontFamily: 'NotoSansKR', fontWeight: '700', color: '#17171B' },
-  headerTintColor: '#17171B', // 뒤로가기 버튼 등 아이콘 색상
+  headerTintColor: '#17171B',
 };
 
-// --- 마이페이지 스택 ---
-const MyPageStackNavigator = () => (
-  <MyPageStack.Navigator
-    screenOptions={mintHeaderOptions}
-  >
-    <MyPageStack.Screen name="MyPageMain" component={MyPageScreen} options={{ title: '내 정보' }} />
-    <MyPageStack.Screen name="AccountManagement" component={AccountManagementScreen} options={{ title: '회원관리' }} />
-    <MyPageStack.Screen name="Favorites" component={FavoritesScreen} options={{ title: '즐겨찾기' }} />
-    <MyPageStack.Screen name="Policy" component={PolicyScreen} options={{ title: '이용약관' }} />
-  </MyPageStack.Navigator>
-);
+// --- 스택 네비게이터들 ---
+const MyPageStackNavigator = () => {
+  const { fontOffset } = useFontSize();
+  return (
+    <MyPageStack.Navigator
+      screenOptions={{
+        ...mintHeaderOptions,
+        headerTitleStyle: {
+          ...mintHeaderOptions.headerTitleStyle,
+          fontSize: responsiveFontSize(18) + fontOffset,
+        }
+      }}
+    >
+      <MyPageStack.Screen name="MyPageMain" component={MyPageScreen} options={{ title: '내 정보' }} />
+      <MyPageStack.Screen name="AccountManagement" component={AccountManagementScreen} options={{ title: '회원관리' }} />
+      <MyPageStack.Screen name="Favorites" component={FavoritesScreen} options={{ title: '즐겨찾기' }} />
+      <MyPageStack.Screen name="Policy" component={PolicyScreen} options={{ title: '이용약관' }} />
+    </MyPageStack.Navigator>
+  );
+};
 
-// --- 가까운 역 스택 ---
-const NearbyStackNavigator = () => (
-  <NearbyStack.Navigator
-    screenOptions={mintHeaderOptions}
-  >
-    <NearbyStack.Screen name="NearbyHome" component={NearbyStationsScreen} options={{ title: '가까운 역 목록' }} />
-    <NearbyStack.Screen name="시설" component={StationFacilitiesScreen} options={{ title: '시설 정보' }} />
-    <NearbyStack.Screen name="역상세" component={StationDetailScreen} options={{ title: '역 상세정보' }} />
-  </NearbyStack.Navigator>
-);
+const NearbyStackNavigator = () => {
+  const { fontOffset } = useFontSize();
+  return (
+    <NearbyStack.Navigator
+      screenOptions={{
+        ...mintHeaderOptions,
+        headerTitleStyle: {
+          ...mintHeaderOptions.headerTitleStyle,
+          fontSize: responsiveFontSize(18) + fontOffset,
+        }
+      }}
+    >
+      <NearbyStack.Screen name="NearbyHome" component={NearbyStationsScreen} options={{ title: '주변 역 목록' }} />
+      <NearbyStack.Screen name="시설" component={StationFacilitiesScreen} options={{ title: '시설 정보' }} />
+      <NearbyStack.Screen name="역상세" component={StationDetailScreen} options={{ title: '역 상세정보' }} />
+    </NearbyStack.Navigator>
+  );
+};
 
-// --- 검색 스택 ---
-const SearchStackNavigator = () => (
-  <SearchStack.Navigator
-    screenOptions={mintHeaderOptions}
-  >
-    <SearchStack.Screen name="SearchHome" component={SearchStationScreen} options={{ title: '역 검색' }} />
-    <SearchStack.Screen name="시설" component={StationFacilitiesScreen} options={{ title: '시설 정보' }} />
-    <SearchStack.Screen name="역상세" component={StationDetailScreen} options={{ title: '역 상세정보' }} />
-  </SearchStack.Navigator>
-);
+const SearchStackNavigator = () => {
+  const { fontOffset } = useFontSize();
+  return (
+    <SearchStack.Navigator
+      screenOptions={{
+        ...mintHeaderOptions,
+        headerTitleStyle: {
+          ...mintHeaderOptions.headerTitleStyle,
+          fontSize: responsiveFontSize(18) + fontOffset,
+        }
+      }}
+    >
+      <SearchStack.Screen name="SearchHome" component={SearchStationScreen} options={{ title: '역 검색' }} />
+      <SearchStack.Screen name="시설" component={StationFacilitiesScreen} options={{ title: '시설 정보' }} />
+      <SearchStack.Screen name="역상세" component={StationDetailScreen} options={{ title: '역 상세정보' }} />
+    </SearchStack.Navigator>
+  );
+};
+
 
 // --- 비로그인 탭 ---
 const GuestTabs = () => {
   const insets = useSafeAreaInsets();
   const navigation = useNavigation();
+  const { fontOffset } = useFontSize();
 
   const tabBarStyle = {
     backgroundColor: '#F9F9F9',
@@ -115,23 +127,36 @@ const GuestTabs = () => {
     shadowOpacity: 0,
     borderTopWidth: 0,
     paddingBottom: Math.max(8, insets.bottom),
-    height: 70 + Math.max(8, insets.bottom),
+    height: 70 + Math.max(8, insets.bottom) + fontOffset,
   };
 
   return (
     <Tab.Navigator
       screenOptions={({ route }) => ({
         ...commonTabOptions,
+        headerTitleStyle: {
+          ...commonTabOptions.headerTitleStyle,
+          fontSize: responsiveFontSize(18) + fontOffset,
+        },
         tabBarStyle,
         tabBarHideOnKeyboard: true,
+        tabBarLabelStyle: {
+          fontSize: responsiveFontSize(16) + fontOffset,
+          fontFamily: 'NotoSansKR',
+          fontWeight: '700',
+          marginBottom: 5,
+        },
         tabBarIcon: ({ focused, size }) => {
           let iconName;
           const iconColor = focused ? '#14CAC9' : 'gray';
+          const iconSize = size + (fontOffset > 0 ? fontOffset / 2 : fontOffset);
+
           if (route.name === '홈') iconName = focused ? 'home' : 'home-outline';
-          else if (route.name === '가까운 역') iconName = focused ? 'navigate-circle' : 'navigate-circle-outline';
+          else if (route.name === '주변') iconName = focused ? 'navigate-circle' : 'navigate-circle-outline';
           else if (route.name === '검색') iconName = focused ? 'search' : 'search-outline';
           else if (route.name === '마이') iconName = focused ? 'person' : 'person-outline';
-          return <Ionicons name={iconName} size={size} color={iconColor} />;
+          
+          return <Ionicons name={iconName} size={iconSize} color={iconColor} />;
         },
       })}
     >
@@ -146,7 +171,8 @@ const GuestTabs = () => {
           },
         }}
       />
-      <Tab.Screen name="가까운 역" component={NearbyStackNavigator} options={{ headerShown: false }} />
+      {/* 👇 [수정] name을 '주변'으로 변경 */}
+      <Tab.Screen name="주변" component={NearbyStackNavigator} options={{ headerShown: false }} />
       <Tab.Screen name="검색" component={SearchStackNavigator} options={{ headerShown: false }} />
       <Tab.Screen
         name="마이"
@@ -173,6 +199,7 @@ const GuestTabs = () => {
 // --- 로그인 탭 ---
 const UserTabs = () => {
   const insets = useSafeAreaInsets();
+  const { fontOffset } = useFontSize();
 
   const tabBarStyle = {
     backgroundColor: '#F9F9F9',
@@ -180,17 +207,28 @@ const UserTabs = () => {
     shadowOpacity: 0,
     borderTopWidth: 0,
     paddingBottom: Math.max(8, insets.bottom),
-    height: 70 + Math.max(8, insets.bottom),
+    height: 70 + Math.max(8, insets.bottom) + fontOffset,
   };
 
   return (
     <Tab.Navigator
       screenOptions={({ route }) => ({
         ...commonTabOptions,
+        headerTitleStyle: {
+          ...commonTabOptions.headerTitleStyle,
+          fontSize: responsiveFontSize(18) + fontOffset,
+        },
         tabBarStyle,
         tabBarHideOnKeyboard: true,
+        tabBarLabelStyle: {
+          fontSize: responsiveFontSize(16) + fontOffset,
+          fontFamily: 'NotoSansKR',
+          fontWeight: '700',
+          marginBottom: 5,
+        },
         tabBarIcon: ({ focused, size }) => {
           const iconColor = focused ? '#14CAC9' : 'gray';
+          const iconSize = size + (fontOffset > 0 ? fontOffset / 2 : fontOffset);
 
           if (route.name === '챗봇') {
             return (
@@ -199,8 +237,8 @@ const UserTabs = () => {
                 accessibilityLabel="챗봇과 대화하기"
                 resizeMode="contain"
                 style={{
-                  width: 70,
-                  height: 70,
+                  width: 70 + fontOffset * 2,
+                  height: 70 + fontOffset * 2,
                   marginBottom: 15,
                 }}
               />
@@ -209,50 +247,59 @@ const UserTabs = () => {
 
           let iconName;
           if (route.name === '홈') iconName = focused ? 'home' : 'home-outline';
-          else if (route.name === '가까운 역') iconName = focused ? 'navigate-circle' : 'navigate-circle-outline';
+          else if (route.name === '주변') iconName = focused ? 'navigate-circle' : 'navigate-circle-outline';
           else if (route.name === '검색') iconName = focused ? 'search' : 'search-outline';
           else if (route.name === '마이') iconName = focused ? 'person' : 'person-outline';
           else iconName = 'ellipse-outline';
 
-          return <Ionicons name={iconName} size={size} color={iconColor} />;
+          return <Ionicons name={iconName} size={iconSize} color={iconColor} />;
         },
       })}
     >
-      <Tab.Screen name="홈" component={MainScreen} options={{ title: '홈' }} />
-      <Tab.Screen name="가까운 역" component={NearbyStackNavigator} options={{ headerShown: false }} />
-      <Tab.Screen name="챗봇" component={ChatBotScreen} options={{ title: '챗봇' }} />
-      <Tab.Screen name="검색" component={SearchStackNavigator} options={{ headerShown: false }} />
-      <Tab.Screen name="마이" component={MyPageStackNavigator} options={{ title: '마이', headerShown: false }} />
+        <Tab.Screen name="홈" component={MainScreen} options={{ title: '홈' }} />
+        {/* 👇 [수정] name을 '주변'으로 변경 */}
+        <Tab.Screen name="주변" component={NearbyStackNavigator} options={{ headerShown: false }} />
+        <Tab.Screen name="챗봇" component={ChatBotScreen} options={{ title: '챗봇' }} />
+        <Tab.Screen name="검색" component={SearchStackNavigator} options={{ headerShown: false }} />
+        <Tab.Screen name="마이" component={MyPageStackNavigator} options={{ title: '마이', headerShown: false }} />
     </Tab.Navigator>
   );
 };
 
-// --- 인증 스택 ---
-const AuthStack = () => (
-  <Stack.Navigator initialRouteName="Welcome">
-    <Stack.Screen name="Welcome" component={WelcomeScreen} options={{ headerShown: false }} />
-    <Stack.Screen name="Login" component={LoginScreen} options={{ title: '로그인' }} />
-    <Stack.Screen name="SignUp" component={SignUpScreen} options={{ title: '회원가입' }} />
-    <Stack.Screen name="FindEmail" component={FindEmailScreen} options={{ title: '이메일 찾기' }} />
-    <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} options={{ title: '비밀번호 찾기' }} />
-    <Stack.Screen name="GuestTabs" component={GuestTabs} options={{ headerShown: false }} />
-  </Stack.Navigator>
-);
-
+// --- 나머지 스택 및 앱 컴포넌트 ---
+const AuthStack = () => {
+  const { fontOffset } = useFontSize();
+  return (
+    <Stack.Navigator
+      initialRouteName="Welcome"
+      screenOptions={{
+        ...mintHeaderOptions,
+        headerTitleStyle: {
+          ...mintHeaderOptions.headerTitleStyle,
+          fontSize: responsiveFontSize(18) + fontOffset,
+        }
+      }}
+    >
+      <Stack.Screen name="Welcome" component={WelcomeScreen} options={{ headerShown: false }} />
+      <Stack.Screen name="Login" component={LoginScreen} options={{ title: '로그인' }} />
+      <Stack.Screen name="SignUp" component={SignUpScreen} options={{ title: '회원가입' }} />
+      <Stack.Screen name="FindEmail" component={FindEmailScreen} options={{ title: '이메일 찾기' }} />
+      <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} options={{ title: '비밀번호 찾기' }} />
+      <Stack.Screen name="GuestTabs" component={GuestTabs} options={{ headerShown: false }} />
+    </Stack.Navigator>
+  );
+};
 const AppStack = () => <UserTabs />;
-// 1. App의 실제 내용을 담을 AppContent 컴포넌트를 새로 만듭니다.
+
 const AppContent = () => {
-  // 2. AuthContext에서 user 정보와 인증 로딩 상태를 가져옵니다.
-  const { user, isLoading: isAuthLoading } = useAuth(); 
-  
+  const { user, isLoading: isAuthLoading } = useAuth();
   const [fontsLoaded] = useFonts({
     NotoSansKR: require('./src/assets/fonts/NotoSansKR-VariableFont_wght.ttf'),
     NotoSans: require('./src/assets/fonts/NotoSans-VariableFont_wdth,wght.ttf'),
     'NotoSans-Italic': require('./src/assets/fonts/NotoSans-Italic-VariableFont_wdth,wght.ttf'),
   });
 
-  // 3. 폰트 로딩과 인증 로딩이 모두 끝날 때까지 로딩 화면을 보여줍니다.
-  if (!fontsLoaded || isAuthLoading) {
+  if (isAuthLoading || !fontsLoaded) {
     return (
       <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
         <ActivityIndicator size="large" />
@@ -260,7 +307,6 @@ const AppContent = () => {
     );
   }
 
-  // 4. 로딩이 끝나면 로그인 상태에 따라 적절한 네비게이터를 보여줍니다.
   return (
     <NavigationContainer>
       {user ? <AppStack /> : <AuthStack />}
@@ -268,10 +314,7 @@ const AppContent = () => {
   );
 };
 
-
-// 5. 최종 App 컴포넌트는 Provider들을 감싸는 역할만 하도록 단순화합니다.
 export default function App() {
-  // GoogleSignin 설정은 앱의 진입점에서 한 번만 실행하면 되므로 여기에 둡니다.
   useEffect(() => {
     const webClientId = process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID;
     if (webClientId) GoogleSignin.configure({ webClientId });
@@ -287,3 +330,4 @@ export default function App() {
     </SafeAreaProvider>
   );
 }
+

--- a/src/components/AuthInput.js
+++ b/src/components/AuthInput.js
@@ -1,15 +1,31 @@
+// src/components/AuthInput.js (수정된 코드)
+
 import React, { useState } from 'react';
 import { View, Text, TextInput, TouchableOpacity } from 'react-native';
 import { styles } from '../styles/authStyles';
 import { Ionicons } from '@expo/vector-icons'; 
 
+// 1. 필요한 훅과 유틸리티를 불러옵니다.
+import { useFontSize } from '../contexts/FontSizeContext';
+import { responsiveFontSize } from '../utils/responsive';
+
 const AuthInput = ({ label, value, onChangeText, error, isPassword, ...props }) => {
   const [isFocused, setIsFocused] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
 
+  // 2. Context에서 fontOffset 값을 가져옵니다.
+  const { fontOffset } = useFontSize();
+
+  // authStyles.js에서 이 컴포넌트 관련 텍스트들의 기본 크기는 모두 16이었습니다.
+  const baseFontSize = 16;
+
   return (
     <View style={styles.inputGroup}>
-      <Text style={styles.label}>{label}</Text>
+      {/* 3. Label 텍스트에 동적 폰트 크기를 적용합니다. */}
+      <Text style={[styles.label, { fontSize: responsiveFontSize(baseFontSize) + fontOffset }]}>
+        {label}
+      </Text>
+      
       <View 
         style={[
           styles.inputContainer, 
@@ -17,14 +33,14 @@ const AuthInput = ({ label, value, onChangeText, error, isPassword, ...props }) 
           error && styles.inputError
         ]}
       >
+        {/* 4. TextInput 자체의 폰트 크기에도 적용합니다. */}
         <TextInput
-          style={styles.inputInner}
+          style={[styles.inputInner, { fontSize: responsiveFontSize(baseFontSize) + fontOffset }]}
           value={value}
           onChangeText={onChangeText}
           secureTextEntry={isPassword && !showPassword}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
-          // ✨ 대비가 높은 placeholder 색상을 적용했습니다.
           placeholderTextColor="#6A6A6A"
           {...props}
         />
@@ -34,10 +50,15 @@ const AuthInput = ({ label, value, onChangeText, error, isPassword, ...props }) 
           </TouchableOpacity>
         )}
       </View>
-      {error && <Text style={styles.errorText}>{error}</Text>}
+
+      {/* 5. Error 텍스트에도 동적 폰트 크기를 적용합니다. */}
+      {error && (
+        <Text style={[styles.errorText, { fontSize: responsiveFontSize(baseFontSize) + fontOffset }]}>
+          {error}
+        </Text>
+      )}
     </View>
   );
 };
 
 export default AuthInput;
-

--- a/src/components/CustomButton.js
+++ b/src/components/CustomButton.js
@@ -79,7 +79,6 @@ const styles = StyleSheet.create({
   },
   featureButtonText: {
     color: '#17171B',
-    // fontSize는 위에서 동적으로 계산하므로 여기서 제거해도 됩니다 (하지만 유지해도 문제 없음).
   },
   outlineButton: {
     backgroundColor: '#FAFAFA',

--- a/src/components/CustomButton.js
+++ b/src/components/CustomButton.js
@@ -1,11 +1,16 @@
-// src/components/CustomButton.js
+// src/components/CustomButton.js (전체 수정 코드)
 
 import React from 'react';
 import { TouchableOpacity, Text, StyleSheet } from 'react-native';
-// 👇 [수정] widthPercentage를 responsiveWidth로 변경
 import { responsiveWidth, responsiveFontSize } from '../utils/responsive';
 
+// 1. 우리가 만든 useFontSize 훅을 불러옵니다.
+import { useFontSize } from '../contexts/FontSizeContext';
+
 const CustomButton = ({ title, onPress, type = 'feature' }) => {
+  // 2. Context에서 fontOffset 값을 가져옵니다.
+  const { fontOffset } = useFontSize();
+
   const getButtonStyles = () => {
     switch (type) {
       case 'outline':
@@ -31,17 +36,27 @@ const CustomButton = ({ title, onPress, type = 'feature' }) => {
         return [styles.textBase, styles.featureButtonText];
     }
   };
+  
+  // 3. 버튼 타입별로 기본 폰트 크기를 정합니다. (기존 StyleSheet 참고)
+  const baseFontSize = type === 'primary' ? 18 : 20;
 
   return (
     <TouchableOpacity style={getButtonStyles()} onPress={onPress}>
-      <Text style={getTextStyles()}>{title}</Text>
+      {/* 4. 최종적으로 Text의 style에 fontOffset을 더한 값을 적용합니다. */}
+      <Text 
+        style={[
+          getTextStyles(), 
+          { fontSize: responsiveFontSize(baseFontSize) + fontOffset }
+        ]}
+      >
+        {title}
+      </Text>
     </TouchableOpacity>
   );
 };
 
 const styles = StyleSheet.create({
   buttonBase: {
-    // 👇 [수정] widthPercentage를 responsiveWidth로 변경
     width: responsiveWidth(300),
     height: responsiveWidth(60),
     justifyContent: 'center',
@@ -64,7 +79,7 @@ const styles = StyleSheet.create({
   },
   featureButtonText: {
     color: '#17171B',
-    fontSize: responsiveFontSize(20),
+    // fontSize는 위에서 동적으로 계산하므로 여기서 제거해도 됩니다 (하지만 유지해도 문제 없음).
   },
   outlineButton: {
     backgroundColor: '#FAFAFA',
@@ -73,7 +88,6 @@ const styles = StyleSheet.create({
   },
   outlineButtonText: {
     color: '#17171B',
-    fontSize: responsiveFontSize(20),
   },
   primaryButton: {
     backgroundColor: '#14CAC9',
@@ -84,14 +98,12 @@ const styles = StyleSheet.create({
   },
   primaryButtonText: {
     color: '#17171B',
-    fontSize: responsiveFontSize(18),
   },
   destructiveButton: {
     backgroundColor: '#D32F2F',
   },
   destructiveButtonText: {
     color: '#FFFFFF',
-    fontSize: responsiveFontSize(20),
   },
 });
 

--- a/src/components/FontSettingModal.js
+++ b/src/components/FontSettingModal.js
@@ -1,0 +1,73 @@
+// src/components/FontSettingModal.js
+
+import React from 'react';
+import { View, Text, Modal, TouchableOpacity, Button, StyleSheet } from 'react-native';
+import { useFontSize } from '../contexts/FontSizeContext';
+import { responsiveFontSize } from '../utils/responsive';
+
+const FontSettingModal = ({ visible, onClose }) => {
+  // 전역 Context에서 필요한 값과 함수를 가져옵니다.
+  const { fontOffset, setFontOffset } = useFontSize();
+
+  return (
+    <Modal
+      animationType="fade"
+      transparent={true}
+      visible={visible}
+      onRequestClose={onClose}
+    >
+      <TouchableOpacity 
+        style={styles.modalBackdrop} 
+        activeOpacity={1} 
+        onPressOut={onClose} // 바깥 영역 클릭 시 닫기
+      >
+        <TouchableOpacity activeOpacity={1} style={styles.modalContainer}>
+          <Text style={[styles.modalTitle, { fontSize: responsiveFontSize(18) + fontOffset }]}>
+            글자 크기 설정
+          </Text>
+          <View style={styles.buttonContainer}>
+            <Button title="작게" onPress={() => setFontOffset(-2)} />
+            <Button title="보통" onPress={() => setFontOffset(0)} />
+            <Button title="크게" onPress={() => setFontOffset(4)} />
+          </View>
+          <Button title="닫기" onPress={onClose} color="#666" />
+        </TouchableOpacity>
+      </TouchableOpacity>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  modalBackdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalContainer: {
+    width: '85%',
+    backgroundColor: 'white',
+    borderRadius: 10,
+    paddingVertical: 20,
+    paddingHorizontal: 25,
+    alignItems: 'center',
+    elevation: 5,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+  },
+  modalTitle: {
+    fontWeight: 'bold',
+    marginBottom: 25,
+    color: '#333'
+  },
+  buttonContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    width: '100%',
+    marginBottom: 20,
+  },
+});
+
+export default FontSettingModal;

--- a/src/components/FontSettingModal.js
+++ b/src/components/FontSettingModal.js
@@ -1,13 +1,19 @@
-// src/components/FontSettingModal.js
-
 import React from 'react';
-import { View, Text, Modal, TouchableOpacity, Button, StyleSheet } from 'react-native';
+import { View, Text, Modal, TouchableOpacity, StyleSheet, Pressable } from 'react-native';
 import { useFontSize } from '../contexts/FontSizeContext';
-import { responsiveFontSize } from '../utils/responsive';
+import { responsiveFontSize, responsiveHeight } from '../utils/responsive'; // responsiveHeight 추가
+import { Ionicons } from '@expo/vector-icons';
 
 const FontSettingModal = ({ visible, onClose }) => {
-  // 전역 Context에서 필요한 값과 함수를 가져옵니다.
   const { fontOffset, setFontOffset } = useFontSize();
+  const isSelected = (offset) => fontOffset === offset;
+
+  const options = [
+    { label: '작게', offset: -2 },
+    { label: '보통', offset: 0 },
+    { label: '크게', offset: 4 },
+    { label: '아주 크게', offset: 8 },
+  ];
 
   return (
     <Modal
@@ -16,23 +22,51 @@ const FontSettingModal = ({ visible, onClose }) => {
       visible={visible}
       onRequestClose={onClose}
     >
-      <TouchableOpacity 
+      <Pressable 
         style={styles.modalBackdrop} 
-        activeOpacity={1} 
-        onPressOut={onClose} // 바깥 영역 클릭 시 닫기
+        onPress={onClose} 
+        accessibilityLabel="닫기"
+        accessibilityRole="button"
       >
         <TouchableOpacity activeOpacity={1} style={styles.modalContainer}>
-          <Text style={[styles.modalTitle, { fontSize: responsiveFontSize(18) + fontOffset }]}>
-            글자 크기 설정
-          </Text>
-          <View style={styles.buttonContainer}>
-            <Button title="작게" onPress={() => setFontOffset(-2)} />
-            <Button title="보통" onPress={() => setFontOffset(0)} />
-            <Button title="크게" onPress={() => setFontOffset(4)} />
-          </View>
-          <Button title="닫기" onPress={onClose} color="#666" />
+            <View style={styles.header}>
+                <Text style={[styles.modalTitle, { fontSize: responsiveFontSize(18) + fontOffset }]}>
+                    글자 크기 설정
+                </Text>
+                <TouchableOpacity onPress={onClose} style={styles.closeButton} accessibilityRole="button" accessibilityLabel="설정 창 닫기">
+                    <Ionicons name="close" size={24} color="#555" />
+                </TouchableOpacity>
+            </View>
+
+            <Text style={[styles.previewText, { fontSize: responsiveFontSize(16) + fontOffset }]}>
+                이 크기로 글자가 보입니다.
+            </Text>
+
+            <View style={styles.optionsContainer}>
+                {options.map((option) => (
+                <TouchableOpacity
+                    key={option.label}
+                    style={[
+                        styles.optionButton,
+                        isSelected(option.offset) && styles.optionButtonSelected,
+                    ]}
+                    onPress={() => setFontOffset(option.offset)}
+                    accessible={true}
+                    accessibilityRole="button"
+                    accessibilityLabel={`글자 크기를 ${option.label}으로 설정`}
+                    accessibilityState={{ selected: isSelected(option.offset) }}
+                >
+                    <Text style={[
+                        styles.optionButtonText,
+                        isSelected(option.offset) && styles.optionButtonTextSelected,
+                    ]}>
+                    {option.label}
+                    </Text>
+                </TouchableOpacity>
+                ))}
+            </View>
         </TouchableOpacity>
-      </TouchableOpacity>
+      </Pressable>
     </Modal>
   );
 };
@@ -40,34 +74,77 @@ const FontSettingModal = ({ visible, onClose }) => {
 const styles = StyleSheet.create({
   modalBackdrop: {
     flex: 1,
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
     justifyContent: 'center',
     alignItems: 'center',
   },
   modalContainer: {
-    width: '85%',
-    backgroundColor: 'white',
-    borderRadius: 10,
-    paddingVertical: 20,
-    paddingHorizontal: 25,
-    alignItems: 'center',
-    elevation: 5,
+    width: '90%',
+    backgroundColor: '#FFFFFF',
+    borderRadius: 16,
+    padding: 24,
+    elevation: 10,
     shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.25,
-    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.2,
+    shadowRadius: 12,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 16,
   },
   modalTitle: {
     fontWeight: 'bold',
-    marginBottom: 25,
-    color: '#333'
+    fontFamily: 'NotoSansKR',
+    color: '#17171B',
   },
-  buttonContainer: {
+  closeButton: {
+    padding: 4,
+  },
+  // --- 👇 멋쟁이님께서 수정한 스타일 반영 ---
+  previewText: {
+    textAlign: 'center',
+    fontFamily: 'NotoSansKR',
+    fontWeight: 'bold',
+    color: '#1A1E22',
+    paddingVertical: 20,
+    backgroundColor: '#F5F5F5',
+    borderRadius: 8,
+    marginBottom: 24,
+  },
+  // --- 👇 2x2 그리드 레이아웃으로 다시 수정 ---
+  optionsContainer: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    width: '100%',
-    marginBottom: 20,
+    flexWrap: 'wrap', 
+  },
+  optionButton: {
+    width: '48%', 
+    paddingVertical: responsiveHeight(16), 
+    marginBottom: responsiveHeight(10), 
+    borderRadius: 8,
+    borderWidth: 1.5,
+    borderColor: '#E0E0E0',
+    backgroundColor: '#FAFAFA',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  optionButtonSelected: {
+    backgroundColor: '#14CAC9',
+    borderColor: '#14CAC9',
+  },
+  optionButtonText: {
+    fontFamily: 'NotoSansKR',
+    fontWeight: '700',
+    fontSize: responsiveFontSize(18),
+    color: '#17171B',
+  },
+  optionButtonTextSelected: {
+    color: '#17171B',
   },
 });
 
 export default FontSettingModal;
+

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -1,0 +1,35 @@
+// src/contexts/AuthContext.js
+
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from '../config/firebaseConfig'; // 기존 firebase 설정 파일
+
+const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    // onAuthStateChanged는 로그인/로그아웃 시 자동으로 user 상태를 알려줍니다.
+    const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
+      setUser(firebaseUser);
+      setIsLoading(false);
+    });
+
+    // 앱이 꺼질 때 감시를 중단합니다.
+    return unsubscribe;
+  }, []);
+
+  return (
+    // user와 로딩 상태를 하위 컴포넌트에 제공합니다.
+    <AuthContext.Provider value={{ user, isLoading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+// 다른 파일에서 user 정보를 쉽게 가져오기 위한 훅
+export const useAuth = () => {
+  return useContext(AuthContext);
+};

--- a/src/contexts/FontSizeContext.js
+++ b/src/contexts/FontSizeContext.js
@@ -1,0 +1,78 @@
+// src/contexts/FontSizeContext.js (최종 수정 코드)
+
+import React, { createContext, useState, useEffect, useContext } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useAuth } from './AuthContext'; // 1. AuthContext 훅 가져오기
+import { getFirestore, doc, getDoc, setDoc } from 'firebase/firestore';
+import { auth } from '../config/firebaseConfig'; // Firebase auth 인스턴스 가져오기
+
+const FONT_OFFSET_KEY = 'font_offset_anonymous'; // 비로그인 사용자용 키
+const defaultFontOffset = 0;
+
+export const FontSizeContext = createContext({
+  fontOffset: defaultFontOffset,
+  setFontOffset: async (newOffset) => {}, // 이름을 setFontOffset으로 다시 통일
+  isLoading: true,
+});
+
+export const FontSizeProvider = ({ children }) => {
+  const { user, isLoading: isAuthLoading } = useAuth(); // 2. user와 인증 로딩 상태 가져오기
+  const [fontOffset, setFontOffsetState] = useState(defaultFontOffset);
+  const [isSettingLoading, setIsSettingLoading] = useState(true);
+  const db = getFirestore();
+
+  useEffect(() => {
+    // 3. 인증 상태 로딩이 끝나면 설정값 로드를 시작
+    if (isAuthLoading) {
+      return; 
+    }
+    
+    const loadSettings = async () => {
+      setIsSettingLoading(true);
+      if (user) {
+        // --- 로그인 사용자: Firebase에서 불러오기 ---
+        const userDocRef = doc(db, 'users', user.uid);
+        const userDoc = await getDoc(userDocRef);
+        if (userDoc.exists() && userDoc.data().accessibilityProfile?.fontScale !== undefined) {
+          setFontOffsetState(userDoc.data().accessibilityProfile.fontScale);
+        } else {
+          setFontOffsetState(defaultFontOffset);
+        }
+      } else {
+        // --- 비로그인 사용자: AsyncStorage에서 불러오기 ---
+        const storedOffset = await AsyncStorage.getItem(FONT_OFFSET_KEY);
+        setFontOffsetState(storedOffset !== null ? Number(storedOffset) : defaultFontOffset);
+      }
+      setIsSettingLoading(false);
+    };
+
+    loadSettings();
+  }, [user, isAuthLoading]); // user나 인증 로딩 상태가 바뀔 때마다 실행
+
+  const setFontOffset = async (newOffset) => {
+    setFontOffsetState(newOffset); // UI 즉시 반영
+
+    if (user) {
+      // --- 로그인 사용자: Firebase에 저장 ---
+      const userDocRef = doc(db, 'users', user.uid);
+      await setDoc(
+        userDocRef,
+        { accessibilityProfile: { fontScale: newOffset } },
+        { merge: true }
+      );
+    } else {
+      // --- 비로그인 사용자: AsyncStorage에 저장 ---
+      await AsyncStorage.setItem(FONT_OFFSET_KEY, String(newOffset));
+    }
+  };
+
+  return (
+    <FontSizeContext.Provider value={{ fontOffset, setFontOffset, isLoading: isSettingLoading }}>
+      {children}
+    </FontSizeContext.Provider>
+  );
+};
+
+export const useFontSize = () => {
+  return useContext(FontSizeContext);
+};

--- a/src/screens/auth/AccountManagementScreen.js
+++ b/src/screens/auth/AccountManagementScreen.js
@@ -1,22 +1,21 @@
-// src/screens/auth/AccountManagementScreen.js
-
+//src/screens/auth/AccountManagementScreen.js
 import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, ScrollView, Alert } from 'react-native';
 import { auth } from '../../config/firebaseConfig';
-import { responsiveWidth, responsiveHeight } from '../../utils/responsive';
+import { responsiveWidth, responsiveHeight, responsiveFontSize } from '../../utils/responsive'; // 1. responsiveFontSize 추가
 import { Ionicons } from '@expo/vector-icons';
 import { logout, deleteAccount } from '../../api/auth';
 import { deleteUserInfo } from '../../api/user';
 import CustomButton from '../../components/CustomButton';
-// 👇 [1. 수정] useNavigation import 제거
-/* import { useNavigation } from '@react-navigation/native'; */
 import { TERMS_OF_SERVICE, LOCATION_POLICY, PRIVACY_POLICY } from '../../constants/policies';
 
-// 👇 [2. 수정] 컴포넌트가 navigation을 직접 prop으로 받도록 변경
+// 2. 필요한 훅 추가
+import { useFontSize } from '../../contexts/FontSizeContext';
+
 const AccountManagementScreen = ({ navigation }) => {
+  // 3. Context에서 fontOffset 값 가져오기
+  const { fontOffset } = useFontSize();
   const user = auth.currentUser;
-  // 👇 [3. 수정] useNavigation() hook 호출 제거 (더 이상 필요 없음)
-  // const navigation = useNavigation();
   
   const handleLogout = async () => { Alert.alert( "로그아웃", "정말 로그아웃 하시겠습니까?", [ { text: "취소", style: "cancel" }, { text: "확인", onPress: async () => await logout() } ] ); };
   const handleDeleteAccount = () => { Alert.alert( "회원 탈퇴", "정말로 계정을 삭제하시겠습니까?\n이 작업은 되돌릴 수 없습니다.", [ { text: "취소", style: "cancel" }, { text: "확인", onPress: async () => { const uid = auth.currentUser?.uid; if (uid) { const userInfoResult = await deleteUserInfo(uid); if (!userInfoResult.success) { Alert.alert("오류", "회원 정보 삭제 중 문제가 발생했습니다."); return; } const accountResult = await deleteAccount(); if (!accountResult.success) { Alert.alert("오류", "계정 삭제 중 문제가 발생했습니다. 다시 로그인 후 시도해주세요."); return; } Alert.alert("탈퇴 완료", "회원 탈퇴가 완료되었습니다."); } }, style: "destructive" } ] ); };
@@ -29,7 +28,8 @@ const AccountManagementScreen = ({ navigation }) => {
     <ScrollView style={styles.container}>
       <View style={styles.mainCard}>
         <View style={styles.greetingCard}>
-          <Text style={styles.greetingText}> {user?.email || '사용자'}님 반갑습니다.</Text>
+          {/* 4. 동적 폰트 크기 적용 */}
+          <Text style={[styles.greetingText, { fontSize: responsiveFontSize(16) + fontOffset }]}> {user?.email || '사용자'}님 반갑습니다.</Text>
         </View>
 
         <CustomButton
@@ -40,7 +40,8 @@ const AccountManagementScreen = ({ navigation }) => {
 
         <View style={styles.infoCard}>
           <View style={styles.cardTitleContainer}>
-            <Text style={styles.cardTitle}>약관 및 정책</Text>
+            {/* 4. 동적 폰트 크기 적용 */}
+            <Text style={[styles.cardTitle, { fontSize: responsiveFontSize(16) + fontOffset }]}>약관 및 정책</Text>
           </View>
           <MenuRow text="서비스 이용 약관" onPress={() => goToPolicy('서비스 이용 약관', TERMS_OF_SERVICE)} accessibilityLabel="서비스 이용 약관 페이지로 이동" />
           <MenuRow text="위치기반 서비스 이용약관" onPress={() => goToPolicy('위치기반 서비스 이용약관', LOCATION_POLICY)} accessibilityLabel="위치기반 서비스 이용약관 페이지로 이동" />
@@ -49,7 +50,8 @@ const AccountManagementScreen = ({ navigation }) => {
 
         <View style={styles.infoCard}>
           <View style={styles.cardTitleContainer}>
-            <Text style={styles.cardTitle}>계정관리</Text>
+            {/* 4. 동적 폰트 크기 적용 */}
+            <Text style={[styles.cardTitle, { fontSize: responsiveFontSize(16) + fontOffset }]}>계정관리</Text>
           </View>
           <MenuRow text="로그아웃" onPress={handleLogout} accessibilityLabel="로그아웃" />
           <MenuRow text="회원탈퇴" onPress={handleDeleteAccount} isDestructive={true} isLast={true} accessibilityLabel="회원탈퇴" />
@@ -59,18 +61,24 @@ const AccountManagementScreen = ({ navigation }) => {
   );
 };
 
-const MenuRow = ({ text, onPress, isDestructive = false, isLast = false, accessibilityLabel }) => (
-  <TouchableOpacity 
-    style={[styles.menuRow, !isLast && styles.menuRowBorder]} 
-    onPress={onPress}
-    accessibilityLabel={accessibilityLabel}
-  >
-    <Text style={[styles.menuRowText, isDestructive && styles.destructiveText]}>{text}</Text>
-    <View accessible={false} style={styles.arrowIconCircle}>
-      <Ionicons name="chevron-forward" size={30} color={isDestructive ? '#ff3b30' : '#171B1B'} />
-    </View>
-  </TouchableOpacity>
-);
+const MenuRow = ({ text, onPress, isDestructive = false, isLast = false, accessibilityLabel }) => {
+  // 5. MenuRow 컴포넌트 내부에서도 Context 훅 사용
+  const { fontOffset } = useFontSize();
+
+  return (
+    <TouchableOpacity 
+      style={[styles.menuRow, !isLast && styles.menuRowBorder]} 
+      onPress={onPress}
+      accessibilityLabel={accessibilityLabel}
+    >
+      {/* 6. 동적 폰트 크기 적용 */}
+      <Text style={[styles.menuRowText, isDestructive && styles.destructiveText, { fontSize: responsiveFontSize(18) + fontOffset }]}>{text}</Text>
+      <View accessible={false} style={styles.arrowIconCircle}>
+        <Ionicons name="chevron-forward" size={30} color={isDestructive ? '#ff3b30' : '#171B1B'} />
+      </View>
+    </TouchableOpacity>
+  );
+};
 
 const styles = StyleSheet.create({
   container: {
@@ -92,7 +100,8 @@ const styles = StyleSheet.create({
   },
   greetingText: {
     fontFamily: 'NotoSansKR',
-    fontSize: responsiveWidth(16),
+    // 7. responsiveWidth -> responsiveFontSize 로 수정 (코드 정확성 향상)
+    fontSize: responsiveFontSize(16), 
     color: '#17171B',
     fontWeight: '700',
   },
@@ -116,7 +125,8 @@ const styles = StyleSheet.create({
   cardTitle: {
     fontFamily: 'NotoSansKR',
     fontWeight: '700',
-    fontSize: responsiveWidth(16),
+    // 7. responsiveWidth -> responsiveFontSize 로 수정 (코드 정확성 향상)
+    fontSize: responsiveFontSize(16),
     color: '#171B1B',
   },
   menuRow: {
@@ -132,7 +142,8 @@ const styles = StyleSheet.create({
   menuRowText: {
     fontFamily: 'NotoSansKR',
     fontWeight: '700',
-    fontSize: responsiveWidth(18),
+    // 7. responsiveWidth -> responsiveFontSize 로 수정 (코드 정확성 향상)
+    fontSize: responsiveFontSize(18),
     color: '#17171B',
   },
   destructiveText: {

--- a/src/screens/auth/FindEmailScreen.js
+++ b/src/screens/auth/FindEmailScreen.js
@@ -1,4 +1,4 @@
-// src/screens/FindEmailScreen.js
+//src/screens/auth/SignUpScreen.js
 import React from 'react';
 import { Text, TouchableOpacity, Alert, ScrollView, KeyboardAvoidingView, Platform, View } from 'react-native';
 import { useAuthForm, SECURITY_QUESTION } from '../../hook/useAuthForm';
@@ -7,28 +7,27 @@ import AuthInput from '../../components/AuthInput';
 import { styles } from '../../styles/authStyles';
 import CustomButton from '../../components/CustomButton';
 
+// 1. 필요한 훅과 유틸리티를 불러옵니다.
+import { useFontSize } from '../../contexts/FontSizeContext';
+import { responsiveFontSize } from '../../utils/responsive';
+
 const FindEmailScreen = ({ navigation }) => {
+  // 2. Context에서 fontOffset 값을 가져옵니다.
+  const { fontOffset } = useFontSize();
+  
   const {
     name, setName, nameError, setNameError,
     dob, setDob, dobError, setDobError,
     securityAnswer, setSecurityAnswer, securityAnswerError, setSecurityAnswerError,
   } = useAuthForm();
 
- // ✨ 이 부분을 아래 새 코드로 바꿔주세요!
   const maskEmail = (email) => {
-    // 이메일을 '@' 기준으로 아이디와 도메인으로 나눕니다.
     const [localPart, domain] = email.split('@');
     const [domainName, topLevelDomain] = domain.split('.');
-
-    // 아이디의 앞 3글자만 남기고 나머지는 '*'로 바꿉니다.
     const maskedLocalPart = localPart.substring(0, 3) + '*'.repeat(localPart.length - 3);
-
-    // 도메인의 첫 글자만 남기고 나머지는 '*'로 바꿉니다.
     const maskedDomainName = domainName.substring(0, 1) + '*'.repeat(domainName.length - 1);
-
     return `${maskedLocalPart}@${maskedDomainName}.${topLevelDomain}`;
   };
-
 
   const handleFindEmail = async () => {
     let isValid = true;
@@ -53,14 +52,24 @@ const FindEmailScreen = ({ navigation }) => {
   return (
     <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : "height"} style={styles.container} keyboardVerticalOffset={60}>
       <ScrollView contentContainerStyle={styles.scrollContainer}>
-        <Text style={styles.title}>이메일 찾기</Text>
+        {/* 3. 각 Text 컴포넌트에 동적 폰트 크기를 적용합니다. */}
+        <Text style={[styles.title, { fontSize: responsiveFontSize(28) + fontOffset }]}>
+          이메일 찾기
+        </Text>
         
+        {/* AuthInput과 CustomButton은 이미 수정되었으므로 그대로 사용합니다. */}
         <AuthInput label="이름" value={name} onChangeText={setName} error={nameError} />
         <AuthInput label="생년월일" placeholder="8자리 입력 (예: 19900101)" value={dob} onChangeText={setDob} error={dobError} keyboardType="number-pad" />
 
         <View style={styles.inputGroup}>
-          <Text style={styles.label}>본인 확인 질문</Text>
-          <View style={styles.questionBox}><Text style={styles.questionText}>{SECURITY_QUESTION}</Text></View>
+          <Text style={[styles.label, { fontSize: responsiveFontSize(16) + fontOffset }]}>
+            본인 확인 질문
+          </Text>
+          <View style={styles.questionBox}>
+            <Text style={[styles.questionText, { fontSize: responsiveFontSize(16) + fontOffset }]}>
+              {SECURITY_QUESTION}
+            </Text>
+          </View>
         </View>
         <AuthInput label="질문에 대한 답변" value={securityAnswer} onChangeText={setSecurityAnswer} error={securityAnswerError} />
 

--- a/src/screens/auth/ForgotPasswordScreen.js
+++ b/src/screens/auth/ForgotPasswordScreen.js
@@ -1,4 +1,4 @@
-// src/screens/ForgotPasswordScreen.js
+//src/screens/auth/ForgotPasswordScreen.js
 import React from 'react';
 import { Text, TouchableOpacity, Alert, ScrollView, KeyboardAvoidingView, Platform } from 'react-native';
 import { useAuthForm } from '../../hook/useAuthForm';
@@ -7,7 +7,14 @@ import AuthInput from '../../components/AuthInput';
 import { styles } from '../../styles/authStyles';
 import CustomButton from '../../components/CustomButton';
 
+// 1. 필요한 훅과 유틸리티를 불러옵니다.
+import { useFontSize } from '../../contexts/FontSizeContext';
+import { responsiveFontSize } from '../../utils/responsive';
+
 const ForgotPasswordScreen = ({ navigation }) => {
+  // 2. Context에서 fontOffset 값을 가져옵니다.
+  const { fontOffset } = useFontSize();
+  
   const {
     email,
     emailError,
@@ -42,9 +49,15 @@ const ForgotPasswordScreen = ({ navigation }) => {
   return (
     <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : "height"} style={styles.container} keyboardVerticalOffset={60}>
       <ScrollView contentContainerStyle={styles.scrollContainer}>
-        <Text style={styles.title}>비밀번호 찾기</Text>
-        <Text style={styles.description}>가입하신 이메일 주소를 입력하시면{"\n"}비밀번호 재설정 링크를 보내드립니다.</Text>
+        {/* 3. 각 Text 컴포넌트에 동적 폰트 크기를 적용합니다. */}
+        <Text style={[styles.title, { fontSize: responsiveFontSize(28) + fontOffset }]}>
+          비밀번호 찾기
+        </Text>
+        <Text style={[styles.description, { fontSize: responsiveFontSize(16) + fontOffset }]}>
+          가입하신 이메일 주소를 입력하시면{"\n"}비밀번호 재설정 링크를 보내드립니다.
+        </Text>
         
+        {/* AuthInput과 CustomButton은 이미 수정되었으므로 그대로 사용합니다. */}
         <AuthInput
           label="이메일 주소"
           value={email}

--- a/src/screens/auth/LoginScreen.js
+++ b/src/screens/auth/LoginScreen.js
@@ -1,3 +1,5 @@
+// src/screens/auth/LoginScreen.js
+
 import React from 'react';
 import { Text, TouchableOpacity, Alert, ScrollView, KeyboardAvoidingView, Platform, View } from 'react-native';
 import { useAuthForm } from '../../hook/useAuthForm';
@@ -6,7 +8,14 @@ import AuthInput from '../../components/AuthInput';
 import CustomButton from '../../components/CustomButton'; 
 import { styles } from '../../styles/authStyles';
 
+// 1. 필요한 훅과 유틸리티를 불러옵니다.
+import { useFontSize } from '../../contexts/FontSizeContext';
+import { responsiveFontSize } from '../../utils/responsive';
+
 const LoginScreen = ({ navigation }) => {
+  // 2. Context에서 fontOffset 값을 가져옵니다.
+  const { fontOffset } = useFontSize();
+  
   const { 
     email,
     password,
@@ -16,8 +25,8 @@ const LoginScreen = ({ navigation }) => {
     setPassword,
     setEmailError,
     setPasswordError,
-   } = useAuthForm();
-   
+  } = useAuthForm();
+    
   const handleLogin = async () => { 
     if (!email || !password) {
       if (!email) setEmailError('이메일을 입력해주세요.');
@@ -38,8 +47,13 @@ const LoginScreen = ({ navigation }) => {
   return (
     <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : "height"} style={styles.container} keyboardVerticalOffset={60}>
       <ScrollView contentContainerStyle={styles.scrollContainer}>
-        <Text style={styles.title}>로그인</Text>
         
+        {/* 3. 각 Text 컴포넌트에 동적 폰트 크기를 적용합니다. */}
+        <Text style={[styles.title, { fontSize: responsiveFontSize(28) + fontOffset }]}>
+          로그인
+        </Text>
+        
+        {/* AuthInput과 CustomButton은 내부적으로 수정했으므로 그대로 사용하면 됩니다. */}
         <AuthInput
           label="이메일 주소"
           value={email}
@@ -55,7 +69,6 @@ const LoginScreen = ({ navigation }) => {
           error={passwordError}
           isPassword={true}
         />
-
         <CustomButton
           type="primary"
           title="로그인"
@@ -64,15 +77,15 @@ const LoginScreen = ({ navigation }) => {
 
         <View style={styles.bottomNavContainer}>
           <TouchableOpacity onPress={() => navigation.navigate('SignUp')}>
-            <Text style={styles.bottomNavLink}>회원가입</Text>
+            <Text style={[styles.bottomNavLink, { fontSize: responsiveFontSize(16) + fontOffset }]}>회원가입</Text>
           </TouchableOpacity>
-          <Text style={styles.bottomNavSeparator}>|</Text>
+          <Text style={[styles.bottomNavSeparator, { fontSize: responsiveFontSize(16) + fontOffset }]}>|</Text>
           <TouchableOpacity onPress={() => { navigation.navigate('FindEmail') }}>
-            <Text style={styles.bottomNavLink}>이메일 찾기</Text>
+            <Text style={[styles.bottomNavLink, { fontSize: responsiveFontSize(16) + fontOffset }]}>이메일 찾기</Text>
           </TouchableOpacity>
-          <Text style={styles.bottomNavSeparator}>|</Text>
+          <Text style={[styles.bottomNavSeparator, { fontSize: responsiveFontSize(16) + fontOffset }]}>|</Text>
           <TouchableOpacity onPress={() => { navigation.navigate('ForgotPassword') }}>
-            <Text style={styles.bottomNavLink}>비밀번호 찾기</Text>
+            <Text style={[styles.bottomNavLink, { fontSize: responsiveFontSize(16) + fontOffset }]}>비밀번호 찾기</Text>
           </TouchableOpacity>
         </View>
       </ScrollView>
@@ -81,4 +94,3 @@ const LoginScreen = ({ navigation }) => {
 };
 
 export default LoginScreen;
-

--- a/src/screens/auth/MyPageScreen.js
+++ b/src/screens/auth/MyPageScreen.js
@@ -1,17 +1,35 @@
-// src/screens/auth/MyPageScreen.js
-
-import React from 'react';
-import { View, StyleSheet } from 'react-native';
+//src/screens/auth/MyPageScreen.js
+import React, { useState } from 'react'; // 1. useState 추가
+import { View, StyleSheet, Text } from 'react-native'; // 1. Text 추가
 import { useNavigation } from '@react-navigation/native';
 import CustomButton from '../../components/CustomButton';
-import { styles as authStyles } from '../../styles/authStyles'; // authStyles import
+import { styles as authStyles } from '../../styles/authStyles'; 
+
+// 2. 필요한 훅과 컴포넌트, 유틸리티 추가
+import { useFontSize } from '../../contexts/FontSizeContext';
+import { responsiveFontSize } from '../../utils/responsive';
+import FontSettingModal from '../../components/FontSettingModal';
 
 const MyPageScreen = () => {
   const navigation = useNavigation();
+  // 3. 모달 상태와 Context 훅 사용
+  const [isModalVisible, setModalVisible] = useState(false);
+  const { fontOffset } = useFontSize();
 
   return (
-    // 👇 [수정] authStyles.container를 적용하고, 내부 요소 정렬을 위한 스타일 추가
     <View style={[authStyles.container, styles.contentContainer]}>
+      {/* 4. 모달 컴포넌트 추가 */}
+      <FontSettingModal 
+        visible={isModalVisible}
+        onClose={() => setModalVisible(false)}
+      />
+
+      {/* 5. 화면 제목 추가 및 동적 폰트 크기 적용 */}
+      <Text style={[styles.title, { fontSize: responsiveFontSize(24) + fontOffset }]}>
+        마이페이지
+      </Text>
+
+      {/* CustomButton들은 자동으로 글자 크기가 조절됩니다. */}
       <CustomButton
         title="즐겨찾기"
         onPress={() => navigation.navigate('Favorites')}
@@ -22,14 +40,29 @@ const MyPageScreen = () => {
         onPress={() => navigation.navigate('AccountManagement')}
         type="feature"
       />
+      {/* 6. 글자 크기 설정 버튼 추가 */}
+      <CustomButton
+        title="글자 크기 설정"
+        onPress={() => setModalVisible(true)}
+        type="outline" // 다른 버튼과 구분되도록 outline 스타일 적용
+      />
     </View>
   );
 };
 
 const styles = StyleSheet.create({
   contentContainer: {
+    flex: 1, // flex: 1 추가하여 전체 화면 사용
     justifyContent: 'center',
     padding: 24,
+  },
+  // 7. 제목 스타일 추가
+  title: {
+    fontFamily: 'NotoSansKR',
+    fontWeight: '700',
+    color: '#17171B',
+    textAlign: 'center',
+    marginBottom: 40, // 버튼과의 간격
   },
 });
 

--- a/src/screens/auth/SignUpScreen.js
+++ b/src/screens/auth/SignUpScreen.js
@@ -1,4 +1,4 @@
-// src/screens/SignUpScreen.js
+//src/screens/auth/SignUpScreen.js
 import React from 'react';
 import { Text, TouchableOpacity, Alert, ScrollView, KeyboardAvoidingView, Platform, View } from 'react-native';
 import { useAuthForm, SECURITY_QUESTION } from '../../hook/useAuthForm';
@@ -8,8 +8,14 @@ import AuthInput from '../../components/AuthInput';
 import { styles } from '../../styles/authStyles';
 import CustomButton from '../../components/CustomButton';
 
+// 1. 필요한 훅과 유틸리티를 불러옵니다.
+import { useFontSize } from '../../contexts/FontSizeContext';
+import { responsiveFontSize } from '../../utils/responsive';
+
 const SignUpScreen = ( ) => {
-  // useAuthForm에서 필요한 모든 상태와 함수를 가져옵니다.
+  // 2. Context에서 fontOffset 값을 가져옵니다.
+  const { fontOffset } = useFontSize();
+
   const {
     name, setName, nameError, setNameError,
     dob, setDob, dobError, setDobError,
@@ -25,7 +31,7 @@ const SignUpScreen = ( ) => {
   } = useAuthForm();
 
   const handleSignUp = async () => {
-    // ✨ 1. 버튼이 눌렸는지 확인하는 로그
+    // ... 기존 회원가입 로직은 그대로 유지 ...
     console.log("--- 회원가입 버튼 클릭됨 ---");
     console.log("입력된 값:", { name, dob, email, password, confirmPassword, securityAnswer });
 
@@ -42,7 +48,6 @@ const SignUpScreen = ( ) => {
     if (!name) {
       setNameError('이름을 입력해주세요.');
       isValid = false;
-      // ✨ 2. 어느 검사에서 실패했는지 확인하는 로그
       console.log("유효성 검사 실패: 이름이 비어있습니다.");
     }
     if (!dob) {
@@ -104,8 +109,12 @@ const SignUpScreen = ( ) => {
   return (
     <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : "height"} style={styles.container} keyboardVerticalOffset={60}>
       <ScrollView contentContainerStyle={styles.scrollContainer}>
-        <Text style={styles.title}>회원가입</Text>
+        {/* 3. 각 Text 컴포넌트에 동적 폰트 크기를 적용합니다. */}
+        <Text style={[styles.title, { fontSize: responsiveFontSize(28) + fontOffset }]}>
+          회원가입
+        </Text>
         
+        {/* AuthInput과 CustomButton은 내부적으로 글자 크기가 조절되므로 그대로 둡니다. */}
         <AuthInput label="이름" value={name} onChangeText={setName} error={nameError} />
         <AuthInput label="생년월일" placeholder="8자리 입력 (예: 19900101)" value={dob} onChangeText={setDob} error={dobError} keyboardType="number-pad" />
         <AuthInput label="이메일 주소" value={email} placeholder="hamkke@example.com" onChangeText={handleEmailChange} error={emailError} keyboardType="email-address" autoCapitalize="none" />
@@ -113,8 +122,14 @@ const SignUpScreen = ( ) => {
         <AuthInput label="비밀번호 확인" value={confirmPassword} onChangeText={handleConfirmPasswordChange} error={confirmPasswordError} isPassword={true} />
 
         <View style={styles.inputGroup}>
-          <Text style={styles.label}>본인 확인 질문</Text>
-          <View style={styles.questionBox}><Text style={styles.questionText}>{SECURITY_QUESTION}</Text></View>
+          <Text style={[styles.label, { fontSize: responsiveFontSize(16) + fontOffset }]}>
+            본인 확인 질문
+          </Text>
+          <View style={styles.questionBox}>
+            <Text style={[styles.questionText, { fontSize: responsiveFontSize(16) + fontOffset }]}>
+              {SECURITY_QUESTION}
+            </Text>
+          </View>
         </View>
         <AuthInput label="질문에 대한 답변" value={securityAnswer} onChangeText={setSecurityAnswer} error={securityAnswerError} />
 

--- a/src/screens/auth/WelcomeScreen.js
+++ b/src/screens/auth/WelcomeScreen.js
@@ -1,18 +1,13 @@
-// src/screens/auth/WelcomeScreen.js (수정된 코드)
-
-import React, { useState } from 'react'; // --- 1. useState 추가 ---
+import React, { useState } from 'react';
 import { View, Text, Alert, SafeAreaView, Image } from 'react-native';
 import { styles } from '../../styles/authStyles';
 import { signInWithGoogle } from '../../api/auth';
 import CustomButton from '../../components/CustomButton';
-
-// --- 2. 필요한 훅과 컴포넌트, 유틸리티 추가 ---
 import { useFontSize } from '../../contexts/FontSizeContext';
 import { responsiveFontSize } from '../../utils/responsive';
 import FontSettingModal from '../../components/FontSettingModal';
 
 const WelcomeScreen = ({ navigation }) => {
-  // --- 3. 모달 표시 상태와 Context 훅 사용 ---
   const [isModalVisible, setModalVisible] = useState(false);
   const { fontOffset } = useFontSize();
 
@@ -25,7 +20,6 @@ const WelcomeScreen = ({ navigation }) => {
   
   return (
     <SafeAreaView style={styles.startContainer}>
-      {/* --- 4. 모달 컴포넌트 추가 --- */}
       <FontSettingModal 
         visible={isModalVisible}
         onClose={() => setModalVisible(false)}
@@ -40,7 +34,6 @@ const WelcomeScreen = ({ navigation }) => {
       </View>
       
       <View style={styles.content}>
-        {/* --- 5. 글자 크기 동적 적용 --- */}
         <Text style={[styles.descriptionText, { fontSize: responsiveFontSize(16) + fontOffset }]}>
           모두를 위한 지하철 이용 도우미,{'\n'}함께타요입니다.
         </Text>
@@ -50,12 +43,18 @@ const WelcomeScreen = ({ navigation }) => {
         <CustomButton
           type="feature"
           title="가까운 역 안내"
-          onPress={() => navigation.navigate('GuestTabs', { screen: '가까운 역' })}
+          onPress={() => navigation.navigate('GuestTabs', { screen: '주변' })}
         />
         <CustomButton
           type="feature"
           title="원하는 역 검색"
           onPress={() => navigation.navigate('GuestTabs', { screen: '검색' })}
+        />
+        {/* --- 👇 [수정] 버튼 위치 이동 및 type 변경 --- */}
+        <CustomButton
+          type="outline" 
+          title="글자 크기 설정"
+          onPress={() => setModalVisible(true)}
         />
         <CustomButton
           type="outline"
@@ -67,15 +66,6 @@ const WelcomeScreen = ({ navigation }) => {
           title="Google로 시작하기"
           onPress={handleGoogleLogin}
         />
-        
-        {/* --- 6. 글자 크기 설정 버튼 추가 --- */}
-        <CustomButton
-          type="outline"
-          title="글자 크기 설정"
-          onPress={() => setModalVisible(true)}
-        />
-        
-        {/* --- 7. 글자 크기 동적 적용 --- */}
         <Text style={[styles.footerText, { fontSize: responsiveFontSize(12) + fontOffset, marginTop: 15 }]}>
           회원 가입 시 {'\n'} 즐겨찾기, 챗봇 기능을 사용할 수 있습니다.
         </Text>
@@ -85,3 +75,4 @@ const WelcomeScreen = ({ navigation }) => {
 };
 
 export default WelcomeScreen;
+

--- a/src/screens/auth/WelcomeScreen.js
+++ b/src/screens/auth/WelcomeScreen.js
@@ -1,10 +1,21 @@
-import React from 'react';
+// src/screens/auth/WelcomeScreen.js (수정된 코드)
+
+import React, { useState } from 'react'; // --- 1. useState 추가 ---
 import { View, Text, Alert, SafeAreaView, Image } from 'react-native';
 import { styles } from '../../styles/authStyles';
 import { signInWithGoogle } from '../../api/auth';
 import CustomButton from '../../components/CustomButton';
 
+// --- 2. 필요한 훅과 컴포넌트, 유틸리티 추가 ---
+import { useFontSize } from '../../contexts/FontSizeContext';
+import { responsiveFontSize } from '../../utils/responsive';
+import FontSettingModal from '../../components/FontSettingModal';
+
 const WelcomeScreen = ({ navigation }) => {
+  // --- 3. 모달 표시 상태와 Context 훅 사용 ---
+  const [isModalVisible, setModalVisible] = useState(false);
+  const { fontOffset } = useFontSize();
+
   const handleGoogleLogin = async () => {
     const { user, error } = await signInWithGoogle();
     if (error) {
@@ -14,6 +25,12 @@ const WelcomeScreen = ({ navigation }) => {
   
   return (
     <SafeAreaView style={styles.startContainer}>
+      {/* --- 4. 모달 컴포넌트 추가 --- */}
+      <FontSettingModal 
+        visible={isModalVisible}
+        onClose={() => setModalVisible(false)}
+      />
+
       <View style={styles.header}>
         <Image 
           source={require('../../../src/assets/brand-icon.png')}
@@ -23,7 +40,8 @@ const WelcomeScreen = ({ navigation }) => {
       </View>
       
       <View style={styles.content}>
-        <Text style={styles.descriptionText}>
+        {/* --- 5. 글자 크기 동적 적용 --- */}
+        <Text style={[styles.descriptionText, { fontSize: responsiveFontSize(16) + fontOffset }]}>
           모두를 위한 지하철 이용 도우미,{'\n'}함께타요입니다.
         </Text>
       </View>
@@ -32,13 +50,11 @@ const WelcomeScreen = ({ navigation }) => {
         <CustomButton
           type="feature"
           title="가까운 역 안내"
-          // ✨ 'GuestTabs'로 이동하며, '안내' 탭을 기본으로 보여주도록 설정합니다.
-          onPress={() => navigation.navigate('GuestTabs', { screen: '안내' })}
+          onPress={() => navigation.navigate('GuestTabs', { screen: '가까운 역' })}
         />
         <CustomButton
           type="feature"
           title="원하는 역 검색"
-          // ✨ 'GuestTabs'로 이동하며, '검색' 탭을 기본으로 보여주도록 설정합니다.
           onPress={() => navigation.navigate('GuestTabs', { screen: '검색' })}
         />
         <CustomButton
@@ -51,7 +67,16 @@ const WelcomeScreen = ({ navigation }) => {
           title="Google로 시작하기"
           onPress={handleGoogleLogin}
         />
-        <Text style={styles.footerText}>
+        
+        {/* --- 6. 글자 크기 설정 버튼 추가 --- */}
+        <CustomButton
+          type="outline"
+          title="글자 크기 설정"
+          onPress={() => setModalVisible(true)}
+        />
+        
+        {/* --- 7. 글자 크기 동적 적용 --- */}
+        <Text style={[styles.footerText, { fontSize: responsiveFontSize(12) + fontOffset, marginTop: 15 }]}>
           회원 가입 시 {'\n'} 즐겨찾기, 챗봇 기능을 사용할 수 있습니다.
         </Text>
       </View>
@@ -60,4 +85,3 @@ const WelcomeScreen = ({ navigation }) => {
 };
 
 export default WelcomeScreen;
-

--- a/src/screens/favorites/FavoritesScreen.js
+++ b/src/screens/favorites/FavoritesScreen.js
@@ -1,12 +1,21 @@
-// src/screens/favorites/FavoritesScreen.js
-
+//src/screens/favorites/FavoritesScreen.js
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 
+// 1. 필요한 훅과 유틸리티를 불러옵니다.
+import { useFontSize } from '../../contexts/FontSizeContext';
+import { responsiveFontSize } from '../../utils/responsive';
+
 const FavoritesScreen = () => {
+  // 2. Context에서 fontOffset 값을 가져옵니다.
+  const { fontOffset } = useFontSize();
+
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>즐겨찾기 기능은 현재 개발 중입니다.</Text>
+      {/* 3. Text 컴포넌트에 동적 폰트 크기를 적용합니다. */}
+      <Text style={[styles.text, { fontSize: responsiveFontSize(18) + fontOffset }]}>
+        즐겨찾기 기능은 현재 개발 중입니다.
+      </Text>
     </View>
   );
 };
@@ -19,7 +28,8 @@ const styles = StyleSheet.create({
     backgroundColor: '#F9F9F9',
   },
   text: {
-    fontSize: 18,
+    // 4. StyleSheet의 fontSize도 responsiveFontSize로 통일합니다.
+    fontSize: responsiveFontSize(18),
     fontFamily: 'NotoSansKR',
     color: '#888',
   },

--- a/src/screens/main/MainScreen.js
+++ b/src/screens/main/MainScreen.js
@@ -1,19 +1,25 @@
-// src/screens/main/MainScreen.js
-import React from 'react';
+// src/screens/main/MainScreen.js (수정된 코드)
+
+import React, { useState } from 'react'; // --- 1. useState 추가 ---
 import { View, SafeAreaView, Text, Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { mainStyles } from '../../styles/mainStyles';
 import CustomButton from '../../components/CustomButton';
 import { auth } from '../../config/firebaseConfig';
 
+// --- 2. 필요한 훅과 컴포넌트, 유틸리티 추가 ---
+import { useFontSize } from '../../contexts/FontSizeContext';
+import { responsiveFontSize } from '../../utils/responsive';
+import FontSettingModal from '../../components/FontSettingModal';
+
 const MainScreen = () => {
   const navigation = useNavigation();
+  // --- 3. 모달 표시 상태와 Context 훅 사용 ---
+  const [isModalVisible, setModalVisible] = useState(false);
+  const { fontOffset } = useFontSize();
 
   const goTab = (name) => {
-    // 같은 TabNavigator 안이므로 바로 이름으로 이동
     navigation.navigate(name);
-    // 만약 이 화면이 탭 바깥에서 렌더링된다면 아래 주석처럼 사용
-    // navigation.navigate('Tabs', { screen: name });
   };
 
   const handleFeaturePress = (featureName) => {
@@ -37,9 +43,16 @@ const MainScreen = () => {
 
   return (
     <SafeAreaView style={mainStyles.container}>
+      {/* --- 4. 모달 컴포넌트 추가 --- */}
+      <FontSettingModal 
+        visible={isModalVisible}
+        onClose={() => setModalVisible(false)}
+      />
+
       <View style={mainStyles.header}>
-        <Text style={mainStyles.greetingText}>
-          {auth.currentUser?.email}님,{"\n"}환영합니다!
+        {/* --- 5. 글자 크기 동적 적용 --- */}
+        <Text style={[mainStyles.greetingText, { fontSize: responsiveFontSize(22) + fontOffset }]}>
+          {auth.currentUser?.displayName || auth.currentUser?.email}님,{"\n"}환영합니다!
         </Text>
       </View>
 
@@ -63,6 +76,12 @@ const MainScreen = () => {
           type="outline"
           title="챗봇"
           onPress={handleChatbotPress}
+        />
+        {/* --- 6. 글자 크기 설정 버튼 추가 --- */}
+        <CustomButton
+          type="outline"
+          title="글자 크기 설정"
+          onPress={() => setModalVisible(true)}
         />
       </View>
     </SafeAreaView>

--- a/src/screens/main/MainScreen.js
+++ b/src/screens/main/MainScreen.js
@@ -1,20 +1,15 @@
-// src/screens/main/MainScreen.js (수정된 코드)
-
-import React, { useState } from 'react'; // --- 1. useState 추가 ---
+import React, { useState } from 'react';
 import { View, SafeAreaView, Text, Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { mainStyles } from '../../styles/mainStyles';
 import CustomButton from '../../components/CustomButton';
 import { auth } from '../../config/firebaseConfig';
-
-// --- 2. 필요한 훅과 컴포넌트, 유틸리티 추가 ---
 import { useFontSize } from '../../contexts/FontSizeContext';
 import { responsiveFontSize } from '../../utils/responsive';
 import FontSettingModal from '../../components/FontSettingModal';
 
 const MainScreen = () => {
   const navigation = useNavigation();
-  // --- 3. 모달 표시 상태와 Context 훅 사용 ---
   const [isModalVisible, setModalVisible] = useState(false);
   const { fontOffset } = useFontSize();
 
@@ -43,14 +38,12 @@ const MainScreen = () => {
 
   return (
     <SafeAreaView style={mainStyles.container}>
-      {/* --- 4. 모달 컴포넌트 추가 --- */}
       <FontSettingModal 
         visible={isModalVisible}
         onClose={() => setModalVisible(false)}
       />
 
       <View style={mainStyles.header}>
-        {/* --- 5. 글자 크기 동적 적용 --- */}
         <Text style={[mainStyles.greetingText, { fontSize: responsiveFontSize(22) + fontOffset }]}>
           {auth.currentUser?.displayName || auth.currentUser?.email}님,{"\n"}환영합니다!
         </Text>
@@ -60,7 +53,8 @@ const MainScreen = () => {
         <CustomButton
           type="feature"
           title="가까운 역 안내"
-          onPress={() => goTab('가까운 역')}
+          // 👇 [수정] '가까운 역' -> '주변'으로 목적지 변경
+          onPress={() => goTab('주변')}
         />
         <CustomButton
           type="feature"
@@ -77,7 +71,6 @@ const MainScreen = () => {
           title="챗봇"
           onPress={handleChatbotPress}
         />
-        {/* --- 6. 글자 크기 설정 버튼 추가 --- */}
         <CustomButton
           type="outline"
           title="글자 크기 설정"
@@ -89,3 +82,4 @@ const MainScreen = () => {
 };
 
 export default MainScreen;
+

--- a/src/screens/nearbystation/NearbyStationsScreen.js
+++ b/src/screens/nearbystation/NearbyStationsScreen.js
@@ -1,3 +1,5 @@
+// src/screens/nearbystation/NearbyStationsScreen.js 
+
 import React, { useState, useEffect } from 'react';
 import {
   View,
@@ -13,6 +15,9 @@ import { Ionicons } from '@expo/vector-icons';
 import stationJson from '../../assets/metro-data/metro/station/data-metro-station-1.0.0.json';
 import lineJson from '../../assets/metro-data/metro/line/data-metro-line-1.0.0.json';
 import { responsiveWidth, responsiveHeight, responsiveFontSize } from '../../utils/responsive';
+
+// 1. 필요한 훅을 불러옵니다.
+import { useFontSize } from '../../contexts/FontSizeContext';
 
 const stationData = stationJson.DATA;
 const lineData = lineJson.DATA;
@@ -35,26 +40,25 @@ function getLineColor(lineNum) {
   return lineInfo ? lineInfo.color : '#666666';
 }
 
-// 👇 [접근성 수정] 배경색에 따라 적절한 텍스트 색상(검/흰)을 반환하는 함수
 function getTextColorForBackground(hexColor) {
   if (!hexColor) return '#FFFFFF';
   const r = parseInt(hexColor.substr(1, 2), 16);
   const g = parseInt(hexColor.substr(3, 2), 16);
   const b = parseInt(hexColor.substr(5, 2), 16);
-  // 밝기 계산 (Luminance formula)
   const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-  return luminance > 0.5 ? '#17171B' : '#FFFFFF'; // 밝으면 검은 글씨, 어두우면 흰 글씨
+  return luminance > 0.5 ? '#17171B' : '#FFFFFF';
 }
 
 
 const NearbyStationsScreen = () => {
+  // 2. Context에서 fontOffset 값을 가져옵니다.
+  const { fontOffset } = useFontSize();
   const navigation = useNavigation();
   const [nearbyStations, setNearbyStations] = useState([]);
   const [errorMsg, setErrorMsg] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    // ... useEffect 로직은 변경 없음 ...
     (async () => {
       setIsLoading(true);
       const { status } = await Location.requestForegroundPermissionsAsync();
@@ -80,16 +84,30 @@ const NearbyStationsScreen = () => {
   }, []);
 
   if (isLoading) {
-    // ... 로딩 UI 변경 없음 ...
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" />
+        {/* 3. 로딩 텍스트에 동적 폰트 크기를 적용합니다. */}
+        <Text style={[styles.loadingText, { fontSize: responsiveFontSize(16) + fontOffset }]}>
+          주변 역을 찾고 있습니다...
+        </Text>
+      </View>
+    );
   }
 
   if (errorMsg) {
-    // ... 에러 UI 변경 없음 ...
+    return (
+      <View style={styles.centered}>
+        {/* 3. 에러 텍스트에 동적 폰트 크기를 적용합니다. */}
+        <Text style={[styles.errorText, { fontSize: responsiveFontSize(16) + fontOffset }]}>
+          {errorMsg}
+        </Text>
+      </View>
+    );
   }
 
   const renderStationItem = ({ item }) => {
     const lineColor = getLineColor(item.line);
-    // 👇 [접근성 수정] 배경색에 맞는 텍스트 색상 계산
     const textColor = getTextColorForBackground(lineColor);
     const accessibilityLabel = `${item.line} ${item.name}, ${item.distance.toFixed(1)}km 거리`;
 
@@ -101,15 +119,17 @@ const NearbyStationsScreen = () => {
         onPress={() => navigation.navigate('시설', { stationName: item.name, line: item.line })}
       >
         <View style={styles.leftContent}>
-          {/* 👇 [디자인 수정] 알약 모양 배지로 변경 */}
           <View style={[styles.lineBadge, { backgroundColor: lineColor }]}>
-            <Text style={[styles.lineBadgeText, { color: textColor }]}>
+            {/* 3. 호선 뱃지 텍스트에 동적 폰트 크기를 적용합니다. */}
+            <Text style={[styles.lineBadgeText, { color: textColor, fontSize: responsiveFontSize(14) + fontOffset }]}>
               {item.line}
             </Text>
           </View>
           <View>
-            <Text style={styles.stationName}>{item.name}</Text>
-            <Text style={styles.distanceText}>
+            {/* 3. 역 이름 텍스트에 동적 폰트 크기를 적용합니다. */}
+            <Text style={[styles.stationName, { fontSize: responsiveFontSize(18) + fontOffset }]}>{item.name}</Text>
+            {/* 3. 거리 텍스트에 동적 폰트 크기를 적용합니다. */}
+            <Text style={[styles.distanceText, { fontSize: responsiveFontSize(15) + fontOffset }]}>
               {item.distance.toFixed(1)} km
             </Text>
           </View>
@@ -179,10 +199,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
   },
-  // 👇 [디자인 수정] 알약 모양, 자동 너비 조절
   lineBadge: {
-    borderRadius: responsiveWidth(40), // 충분히 둥글게
-    paddingHorizontal: responsiveWidth(12), // 좌우 여백으로 너비 조절
+    borderRadius: responsiveWidth(40),
+    paddingHorizontal: responsiveWidth(12),
     paddingVertical: responsiveHeight(5),
     justifyContent: 'center',
     alignItems: 'center',
@@ -190,7 +209,7 @@ const styles = StyleSheet.create({
   },
   lineBadgeText: {
     fontSize: responsiveFontSize(14),
-    fontWeight: '700', // 굵기를 700으로 낮춰 가독성 확보
+    fontWeight: '700',
   },
   stationName: {
     fontSize: responsiveFontSize(18),

--- a/src/screens/policy/PolicyScreen.js
+++ b/src/screens/policy/PolicyScreen.js
@@ -1,24 +1,27 @@
-// src/screens/policy/PolicyScreen.js
-
+//src/screens/policy/PolicyScreen.js
 import React from 'react';
 import { ScrollView, Text, StyleSheet } from 'react-native';
-// 👇 [1. 수정] useNavigation을 더 이상 사용하지 않으므로 import 문 정리
 import { useRoute } from '@react-navigation/native';
-import { responsiveWidth, responsiveHeight } from '../../utils/responsive';
+// 1. 필요한 훅과 유틸리티를 불러옵니다.
+import { responsiveWidth, responsiveHeight, responsiveFontSize } from '../../utils/responsive';
+import { useFontSize } from '../../contexts/FontSizeContext';
 
-// 👇 [2. 수정] 컴포넌트가 navigation을 직접 prop으로 받도록 변경
 const PolicyScreen = ({ navigation }) => {
+  // 2. Context에서 fontOffset 값을 가져옵니다.
+  const { fontOffset } = useFontSize();
   const route = useRoute();
   const { title, content } = route.params;
 
-  // 헤더 제목을 동적으로 변경하기 위해 navigation을 사용
   React.useLayoutEffect(() => {
     navigation.setOptions({ title });
   }, [navigation, title]);
 
   return (
     <ScrollView style={styles.container}>
-      <Text style={styles.content}>{content}</Text>
+      {/* 3. Text 컴포넌트에 동적 폰트 크기를 적용합니다. */}
+      <Text style={[styles.content, { fontSize: responsiveFontSize(14) + fontOffset }]}>
+        {content}
+      </Text>
     </ScrollView>
   );
 };
@@ -31,7 +34,8 @@ const styles = StyleSheet.create({
   },
   content: {
     fontFamily: 'NotoSansKR',
-    fontSize: responsiveWidth(14),
+    // 4. responsiveWidth -> responsiveFontSize 로 수정 (코드 정확성 향상)
+    fontSize: responsiveFontSize(14),
     fontWeight: '700',
     lineHeight: responsiveHeight(24),
     color: '#17171B',

--- a/src/screens/searchstation/SearchStationScreen.js
+++ b/src/screens/searchstation/SearchStationScreen.js
@@ -1,4 +1,4 @@
-// src/screens/searchstation/SearchStationScreen.js
+//src/screens/searchstation/SearchStationScreen.js
 import React, { useState, useMemo } from 'react';
 import {
   View,
@@ -13,29 +13,28 @@ import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import stationJson from '../../assets/metro-data/metro/station/data-metro-station-1.0.0.json';
 import lineJson from '../../assets/metro-data/metro/line/data-metro-line-1.0.0.json';
+import { useFontSize } from '../../contexts/FontSizeContext';
+import { responsiveFontSize, responsiveHeight } from '../../utils/responsive'; // responsiveHeight 추가
 
-// 데이터
 const allStations = stationJson.DATA;
 const lineData = lineJson.DATA;
 
-// 호선 → 색상
 function getLineColor(lineNum) {
   const lineInfo = lineData.find((l) => l.line === lineNum);
   return lineInfo ? lineInfo.color : '#666666';
 }
 
 const SearchStationScreen = () => {
+  const { fontOffset } = useFontSize();
   const navigation = useNavigation();
   const [searchQuery, setSearchQuery] = useState('');
 
   const searchResults = useMemo(() => {
     const q = searchQuery.trim();
     if (!q) return [];
-
     const matchingStations = allStations.filter((station) =>
       station.name.startsWith(q)
     );
-
     const stationMap = new Map();
     matchingStations.forEach((station) => {
       if (stationMap.has(station.name)) {
@@ -44,7 +43,6 @@ const SearchStationScreen = () => {
         stationMap.set(station.name, { name: station.name, lines: [station.line] });
       }
     });
-
     return Array.from(stationMap.values());
   }, [searchQuery]);
 
@@ -54,7 +52,7 @@ const SearchStationScreen = () => {
       <View style={styles.searchContainer}>
         <Ionicons name="search" size={20} color="#8e8e93" style={styles.searchIcon} />
         <TextInput
-          style={styles.input}
+          style={[styles.input, { fontSize: responsiveFontSize(16) + fontOffset }]}
           placeholder="역 이름을 입력하세요"
           value={searchQuery}
           onChangeText={setSearchQuery}
@@ -63,7 +61,7 @@ const SearchStationScreen = () => {
         />
         {searchQuery.length > 0 && (
           <View style={styles.searchButton}>
-            <Text style={styles.searchButtonText}>검색</Text>
+            <Text style={[styles.searchButtonText, { fontSize: responsiveFontSize(14) + fontOffset }]}>검색</Text>
           </View>
         )}
       </View>
@@ -79,7 +77,6 @@ const SearchStationScreen = () => {
             <TouchableOpacity
               activeOpacity={0.85}
               style={styles.resultItem}
-              // ⬇️ 같은 탭의 스택(SearchStackNavigator)으로 push → 탭바 유지
               onPress={() =>
                 navigation.navigate('시설', { stationName: item.name, line: firstLine })
               }
@@ -94,14 +91,14 @@ const SearchStationScreen = () => {
                 color="black"
                 style={styles.locationIcon}
               />
-              <Text style={styles.stationName}>{item.name}</Text>
+              <Text style={[styles.stationName, { fontSize: responsiveFontSize(16) + fontOffset }]}>{item.name}</Text>
               <View style={styles.lineContainer}>
                 {item.lines.map((line) => (
                   <View
                     key={line}
                     style={[styles.lineCircle, { backgroundColor: getLineColor(line) }]}
                   >
-                    <Text style={styles.lineText}>{line.replace('호선', '')}</Text>
+                    <Text style={[styles.lineText, { fontSize: responsiveFontSize(12) + fontOffset }]}>{line.replace('호선', '')}</Text>
                   </View>
                 ))}
               </View>
@@ -110,7 +107,7 @@ const SearchStationScreen = () => {
         }}
         ListEmptyComponent={
           searchQuery.length > 0 ? (
-            <Text style={styles.emptyText}>검색 결과가 없습니다.</Text>
+            <Text style={[styles.emptyText, { fontSize: responsiveFontSize(16) + fontOffset }]}>검색 결과가 없습니다.</Text>
           ) : null
         }
       />
@@ -126,30 +123,35 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16, paddingVertical: 12,
     borderBottomWidth: 1, borderBottomColor: '#e5e5e5',
   },
-  headerTitle: { fontSize: 18, fontWeight: '600', marginLeft: 16 },
+  headerTitle: { fontSize: responsiveFontSize(18), fontWeight: '600', marginLeft: 16 },
   searchContainer: {
     flexDirection: 'row', alignItems: 'center',
     backgroundColor: '#f0f0f0', borderRadius: 20,
     margin: 16, paddingHorizontal: 12,
   },
   searchIcon: { marginRight: 8 },
-  input: { flex: 1, height: 40, fontSize: 16 },
-  searchButton: { backgroundColor: '#00B8D4', borderRadius: 15, paddingHorizontal: 12, paddingVertical: 6 },
-  searchButtonText: { color: 'white', fontWeight: 'bold' },
+  // 👇 [수정] 고정 높이를 삭제하고, 세로 여백(paddingVertical)으로 대체
+  input: {
+    flex: 1,
+    paddingVertical: responsiveHeight(10), // 높이가 유동적으로 변하도록 수정
+    fontSize: responsiveFontSize(16),
+  },
+  searchButton: { backgroundColor: '#00B8D4', borderRadius: 15, paddingHorizontal: 12, paddingVertical: 6, marginLeft: 4 },
+  searchButtonText: { color: 'white', fontWeight: 'bold', fontSize: responsiveFontSize(14) },
   resultItem: {
     flexDirection: 'row', alignItems: 'center',
     paddingHorizontal: 16, paddingVertical: 12,
     borderBottomWidth: 1, borderBottomColor: '#f0f0f0',
   },
   locationIcon: { marginRight: 12 },
-  stationName: { flex: 1, fontSize: 16 },
+  stationName: { flex: 1, fontSize: responsiveFontSize(16) },
   lineContainer: { flexDirection: 'row' },
   lineCircle: {
     width: 24, height: 24, borderRadius: 12,
     justifyContent: 'center', alignItems: 'center', marginLeft: 8,
   },
-  lineText: { color: 'white', fontSize: 12, fontWeight: 'bold' },
-  emptyText: { textAlign: 'center', marginTop: 20, color: 'gray' },
+  lineText: { color: 'white', fontSize: responsiveFontSize(12), fontWeight: 'bold' },
+  emptyText: { textAlign: 'center', marginTop: 20, color: 'gray', fontSize: responsiveFontSize(16) },
 });
 
 export default SearchStationScreen;

--- a/src/screens/searchstation/SearchStationScreen.js
+++ b/src/screens/searchstation/SearchStationScreen.js
@@ -1,4 +1,3 @@
-//src/screens/searchstation/SearchStationScreen.js
 import React, { useState, useMemo } from 'react';
 import {
   View,
@@ -14,7 +13,7 @@ import { useNavigation } from '@react-navigation/native';
 import stationJson from '../../assets/metro-data/metro/station/data-metro-station-1.0.0.json';
 import lineJson from '../../assets/metro-data/metro/line/data-metro-line-1.0.0.json';
 import { useFontSize } from '../../contexts/FontSizeContext';
-import { responsiveFontSize, responsiveHeight } from '../../utils/responsive'; // responsiveHeight 추가
+import { responsiveFontSize, responsiveHeight } from '../../utils/responsive';
 
 const allStations = stationJson.DATA;
 const lineData = lineJson.DATA;
@@ -48,7 +47,6 @@ const SearchStationScreen = () => {
 
   return (
     <SafeAreaView style={styles.container}>
-      {/* 검색창 */}
       <View style={styles.searchContainer}>
         <Ionicons name="search" size={20} color="#8e8e93" style={styles.searchIcon} />
         <TextInput
@@ -66,7 +64,6 @@ const SearchStationScreen = () => {
         )}
       </View>
 
-      {/* 검색 결과 */}
       <FlatList
         data={searchResults}
         keyExtractor={(item) => item.name}
@@ -115,7 +112,6 @@ const SearchStationScreen = () => {
   );
 };
 
-// 스타일
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: '#fff' },
   header: {
@@ -123,35 +119,67 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16, paddingVertical: 12,
     borderBottomWidth: 1, borderBottomColor: '#e5e5e5',
   },
-  headerTitle: { fontSize: responsiveFontSize(18), fontWeight: '600', marginLeft: 16 },
+  headerTitle: { 
+    fontSize: responsiveFontSize(18), 
+    fontWeight: 'bold', 
+    marginLeft: 16,
+    fontFamily: 'NotoSansKR',
+  },
   searchContainer: {
     flexDirection: 'row', alignItems: 'center',
     backgroundColor: '#f0f0f0', borderRadius: 20,
     margin: 16, paddingHorizontal: 12,
   },
   searchIcon: { marginRight: 8 },
-  // 👇 [수정] 고정 높이를 삭제하고, 세로 여백(paddingVertical)으로 대체
+  // 👇 [수정] fontFamily와 fontWeight 추가
   input: {
     flex: 1,
-    paddingVertical: responsiveHeight(10), // 높이가 유동적으로 변하도록 수정
+    paddingVertical: responsiveHeight(10),
     fontSize: responsiveFontSize(16),
+    fontFamily: 'NotoSansKR',
+    fontWeight: 'bold',
   },
   searchButton: { backgroundColor: '#00B8D4', borderRadius: 15, paddingHorizontal: 12, paddingVertical: 6, marginLeft: 4 },
-  searchButtonText: { color: 'white', fontWeight: 'bold', fontSize: responsiveFontSize(14) },
+  searchButtonText: { 
+    color: 'white', 
+    fontWeight: 'bold', 
+    fontSize: responsiveFontSize(14),
+    fontFamily: 'NotoSansKR',
+  },
   resultItem: {
     flexDirection: 'row', alignItems: 'center',
     paddingHorizontal: 16, paddingVertical: 12,
     borderBottomWidth: 1, borderBottomColor: '#f0f0f0',
   },
   locationIcon: { marginRight: 12 },
-  stationName: { flex: 1, fontSize: responsiveFontSize(16) },
+  // 👇 [수정] fontFamily와 fontWeight 추가
+  stationName: { 
+    flex: 1, 
+    fontSize: responsiveFontSize(16),
+    fontFamily: 'NotoSansKR',
+    fontWeight: 'bold',
+  },
   lineContainer: { flexDirection: 'row' },
   lineCircle: {
     width: 24, height: 24, borderRadius: 12,
     justifyContent: 'center', alignItems: 'center', marginLeft: 8,
   },
-  lineText: { color: 'white', fontSize: responsiveFontSize(12), fontWeight: 'bold' },
-  emptyText: { textAlign: 'center', marginTop: 20, color: 'gray', fontSize: responsiveFontSize(16) },
+  lineText: { 
+    color: 'white', 
+    fontSize: responsiveFontSize(12), 
+    fontWeight: 'bold',
+    fontFamily: 'NotoSansKR',
+  },
+  // 👇 [수정] fontFamily와 fontWeight 추가
+  emptyText: { 
+    textAlign: 'center', 
+    marginTop: 20, 
+    color: 'gray', 
+    fontSize: responsiveFontSize(16),
+    fontFamily: 'NotoSansKR',
+    fontWeight: 'bold',
+  },
 });
 
 export default SearchStationScreen;
+

--- a/src/screens/station/StationDetailScreen.js
+++ b/src/screens/station/StationDetailScreen.js
@@ -1,4 +1,3 @@
-//src/screens/station/StationDetailScreen.js
 import React, { useEffect, useState } from "react";
 import {
   View,
@@ -8,16 +7,12 @@ import {
   StyleSheet,
   FlatList,
 } from "react-native";
-
-// 1. 필요한 훅과 유틸리티를 불러옵니다.
 import { useFontSize } from "../../contexts/FontSizeContext";
 import { responsiveFontSize, responsiveHeight } from "../../utils/responsive";
-
-// 로컬 JSON 데이터 (기존과 동일)
 import elevJson from "../../assets/metro-data/metro/elevator/서울교통공사_교통약자_이용시설_승강기_가동현황.json";
 import stationJson from "../../assets/metro-data/metro/station/data-metro-station-1.0.0.json";
 
-/* --- 유틸 함수 및 데이터 인덱싱 (전체 코드) --- */
+/* --- 유틸 함수 및 데이터 인덱싱 --- */
 const sanitizeName = (s = "") => (typeof s === "string" ? s.replace(/\(\s*\d+\s*\)$/g, "").trim() : "");
 const normalizeLine = (line = "") => {
   const m = String(line).match(/(\d+)/);
@@ -25,12 +20,7 @@ const normalizeLine = (line = "") => {
 };
 const koStatus = (v = "") => (v === "Y" ? "사용가능" : v === "N" ? "중지" : v || "-");
 const koKind = (k = "") => (k === "EV" ? "엘리베이터" : k === "ES" ? "에스컬레이터" : k === "WL" ? "휠체어리프트" : k || "-");
-
-const STATION_ROWS = Array.isArray(stationJson?.DATA)
-  ? stationJson.DATA
-  : Array.isArray(stationJson)
-  ? stationJson
-  : [];
+const STATION_ROWS = Array.isArray(stationJson?.DATA) ? stationJson.DATA : Array.isArray(stationJson) ? stationJson : [];
 const META_BY_CODE = new Map();
 for (const r of STATION_ROWS) {
   const code = (r.station_cd ?? r.fr_code ?? r.bldn_id ?? "").toString().trim();
@@ -41,7 +31,6 @@ for (const r of STATION_ROWS) {
     line: normalizeLine(r.line ?? ""),
   });
 }
-
 function pickElevArray(any) {
   if (Array.isArray(any)) return any;
   if (Array.isArray(any?.DATA)) return any.DATA;
@@ -56,14 +45,9 @@ function pickElevArray(any) {
   }
   return [];
 }
-
 function normalizeElevRow(raw) {
-  const stationCode = String(
-    raw.station_cd ?? raw.STN_CD ?? raw.code ?? raw.stationCode ?? ""
-  ).trim();
-  const stationName = sanitizeName(
-    raw.station_nm ?? raw.STN_NM ?? raw.name ?? raw.stationName ?? ""
-  );
+  const stationCode = String(raw.station_cd ?? raw.STN_CD ?? raw.code ?? raw.stationCode ?? "").trim();
+  const stationName = sanitizeName(raw.station_nm ?? raw.STN_NM ?? raw.name ?? raw.stationName ?? "");
   const facilityName = raw.elvtr_nm ?? raw.ELVTR_NM ?? raw.facilityName ?? "";
   const section = raw.opr_sec ?? raw.OPR_SEC ?? raw.section ?? "";
   const gate = raw.instl_pstn ?? raw.INSTL_PSTN ?? raw.location ?? raw.gate ?? "";
@@ -71,18 +55,8 @@ function normalizeElevRow(raw) {
   const kind = raw.elvtr_se ?? raw.ELVTR_SE ?? raw.kind ?? "";
   const meta = META_BY_CODE.get(stationCode) || {};
   const line = meta.line || normalizeLine(raw.line ?? raw.LINE_NUM ?? raw.lineName ?? "");
-  return {
-    stationCode,
-    stationName: stationName || meta.name || "",
-    line,
-    facilityName,
-    section,
-    gate,
-    status,
-    kind,
-  };
+  return { stationCode, stationName: stationName || meta.name || "", line, facilityName, section, gate, status, kind };
 }
-
 const ELEV_ROWS = pickElevArray(elevJson).map(normalizeElevRow);
 const BY_CODE = new Map();
 const BY_NAME = new Map();
@@ -190,7 +164,7 @@ const s = StyleSheet.create({
   center: { flex: 1, alignItems: "center", justifyContent: "center", padding: 16, backgroundColor: '#FFFFFF' },
   centerText: {
     fontFamily: 'NotoSansKR',
-    fontWeight: '700',
+    fontWeight: 'bold', // '700' -> 'bold'
     color: '#333',
   },
   header: {
@@ -201,7 +175,7 @@ const s = StyleSheet.create({
   },
   headerTitle: { 
     fontSize: responsiveFontSize(20), 
-    fontWeight: "700",
+    fontWeight: "bold", // '700' -> 'bold'
     fontFamily: 'NotoSansKR',
     color: '#17171B',
   },
@@ -210,7 +184,7 @@ const s = StyleSheet.create({
     color: "#666",
     fontSize: responsiveFontSize(14),
     fontFamily: 'NotoSansKR',
-    fontWeight: '500',
+    fontWeight: 'bold', // '500' -> 'bold'
   },
   row: { 
     paddingVertical: 12,
@@ -219,7 +193,7 @@ const s = StyleSheet.create({
     borderColor: "#f1f1f1" 
   },
   rowName: { 
-    fontWeight: "700", 
+    fontWeight: "bold", // '700' -> 'bold'
     marginBottom: 8,
     fontSize: responsiveFontSize(16),
     fontFamily: 'NotoSansKR',
@@ -230,6 +204,7 @@ const s = StyleSheet.create({
     fontFamily: 'NotoSansKR',
     color: '#333',
     lineHeight: responsiveHeight(22),
+    fontWeight: 'bold', // fontWeight 추가
   }
 });
 

--- a/src/screens/station/StationDetailScreen.js
+++ b/src/screens/station/StationDetailScreen.js
@@ -1,3 +1,4 @@
+//src/screens/station/StationDetailScreen.js
 import React, { useEffect, useState } from "react";
 import {
   View,
@@ -8,23 +9,23 @@ import {
   FlatList,
 } from "react-native";
 
-// ✅ 로컬 JSON 직사용
+// 1. 필요한 훅과 유틸리티를 불러옵니다.
+import { useFontSize } from "../../contexts/FontSizeContext";
+import { responsiveFontSize, responsiveHeight } from "../../utils/responsive";
+
+// 로컬 JSON 데이터 (기존과 동일)
 import elevJson from "../../assets/metro-data/metro/elevator/서울교통공사_교통약자_이용시설_승강기_가동현황.json";
 import stationJson from "../../assets/metro-data/metro/station/data-metro-station-1.0.0.json";
 
-/* ---------- 유틸 ---------- */
-const sanitizeName = (s = "") =>
-  typeof s === "string" ? s.replace(/\(\s*\d+\s*\)$/g, "").trim() : "";
+/* --- 유틸 함수 및 데이터 인덱싱 (전체 코드) --- */
+const sanitizeName = (s = "") => (typeof s === "string" ? s.replace(/\(\s*\d+\s*\)$/g, "").trim() : "");
 const normalizeLine = (line = "") => {
   const m = String(line).match(/(\d+)/);
   return m ? `${parseInt(m[1], 10)}호선` : String(line);
 };
-const koStatus = (v = "") =>
-  v === "Y" ? "사용가능" : v === "N" ? "중지" : v || "-";
-const koKind = (k = "") =>
-  k === "EV" ? "엘리베이터" : k === "ES" ? "에스컬레이터" : k === "WL" ? "휠체어리프트" : k || "-";
+const koStatus = (v = "") => (v === "Y" ? "사용가능" : v === "N" ? "중지" : v || "-");
+const koKind = (k = "") => (k === "EV" ? "엘리베이터" : k === "ES" ? "에스컬레이터" : k === "WL" ? "휠체어리프트" : k || "-");
 
-/* ---------- 역 메타 인덱스 (코드→이름/호선) ---------- */
 const STATION_ROWS = Array.isArray(stationJson?.DATA)
   ? stationJson.DATA
   : Array.isArray(stationJson)
@@ -41,7 +42,6 @@ for (const r of STATION_ROWS) {
   });
 }
 
-/* ---------- 엘리베이터 JSON 파싱/정규화 ---------- */
 function pickElevArray(any) {
   if (Array.isArray(any)) return any;
   if (Array.isArray(any?.DATA)) return any.DATA;
@@ -102,6 +102,7 @@ for (const r of ELEV_ROWS) {
 
 /* ---------- 컴포넌트 ---------- */
 export default function StationDetailScreen({ route }) {
+  const { fontOffset } = useFontSize();
   const { stationCode, stationName } = route.params ?? {};
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState(null);
@@ -126,46 +127,54 @@ export default function StationDetailScreen({ route }) {
     return (
       <SafeAreaView style={s.center}>
         <ActivityIndicator />
-        <Text style={{ marginTop: 8 }}>불러오는 중…</Text>
+        <Text style={[s.centerText, { fontSize: responsiveFontSize(16) + fontOffset, marginTop: 8 }]}>
+          불러오는 중…
+        </Text>
       </SafeAreaView>
     );
   }
   if (err) {
     return (
       <SafeAreaView style={s.center}>
-        <Text style={{ color: "red", fontWeight: "600" }}>오류: {err}</Text>
+        <Text style={[s.centerText, { color: "red", fontSize: responsiveFontSize(16) + fontOffset }]}>
+          오류: {err}
+        </Text>
       </SafeAreaView>
     );
   }
   if (rows.length === 0) {
     return (
       <SafeAreaView style={s.center}>
-        <Text>표시할 시설 정보가 없습니다.</Text>
+        <Text style={[s.centerText, { fontSize: responsiveFontSize(16) + fontOffset }]}>
+          표시할 시설 정보가 없습니다.
+        </Text>
       </SafeAreaView>
     );
   }
 
   const Header = () => (
     <View style={s.header}>
-      <Text style={s.headerTitle}>
+      <Text style={[s.headerTitle, { fontSize: responsiveFontSize(20) + fontOffset }]}>
         {rows[0]?.stationName} ({rows[0]?.stationCode})
       </Text>
-      <Text style={s.headerSub}>상세 시설 정보</Text>
+      <Text style={[s.headerSub, { fontSize: responsiveFontSize(14) + fontOffset }]}>
+        상세 시설 정보
+      </Text>
     </View>
   );
 
   const renderItem = ({ item }) => (
     <View style={s.row}>
-      <Text style={s.rowName}>{item.facilityName}</Text>
-      <Text>위치: {item.gate || "-"}</Text>
-      <Text>구간: {item.section || "-"}</Text>
-      <Text>상태: {item.status || "-"}</Text>
-      <Text>종류: {koKind(item.kind)}</Text>
+      <Text style={[s.rowName, { fontSize: responsiveFontSize(16) + fontOffset }]}>{item.facilityName}</Text>
+      <Text style={[s.rowText, { fontSize: responsiveFontSize(14) + fontOffset }]}>위치: {item.gate || "-"}</Text>
+      <Text style={[s.rowText, { fontSize: responsiveFontSize(14) + fontOffset }]}>구간: {item.section || "-"}</Text>
+      <Text style={[s.rowText, { fontSize: responsiveFontSize(14) + fontOffset }]}>상태: {item.status || "-"}</Text>
+      <Text style={[s.rowText, { fontSize: responsiveFontSize(14) + fontOffset }]}>종류: {koKind(item.kind)}</Text>
     </View>
   );
 
   return (
-    <SafeAreaView style={{ flex: 1 }}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: '#FFFFFF' }}>
       <FlatList
         data={rows}
         keyExtractor={(_, idx) => String(idx)}
@@ -178,15 +187,49 @@ export default function StationDetailScreen({ route }) {
 }
 
 const s = StyleSheet.create({
-  center: { flex: 1, alignItems: "center", justifyContent: "center", padding: 16 },
+  center: { flex: 1, alignItems: "center", justifyContent: "center", padding: 16, backgroundColor: '#FFFFFF' },
+  centerText: {
+    fontFamily: 'NotoSansKR',
+    fontWeight: '700',
+    color: '#333',
+  },
   header: {
-    padding: 12,
+    padding: 16,
     borderBottomWidth: 1,
     borderColor: "#eee",
     backgroundColor: "#fafafa",
   },
-  headerTitle: { fontSize: 18, fontWeight: "700" },
-  headerSub: { marginTop: 4, color: "#666" },
-  row: { padding: 12, borderBottomWidth: 1, borderColor: "#f1f1f1" },
-  rowName: { fontWeight: "600", marginBottom: 4 },
+  headerTitle: { 
+    fontSize: responsiveFontSize(20), 
+    fontWeight: "700",
+    fontFamily: 'NotoSansKR',
+    color: '#17171B',
+  },
+  headerSub: { 
+    marginTop: 4, 
+    color: "#666",
+    fontSize: responsiveFontSize(14),
+    fontFamily: 'NotoSansKR',
+    fontWeight: '500',
+  },
+  row: { 
+    paddingVertical: 12,
+    paddingHorizontal: 16, 
+    borderBottomWidth: 1, 
+    borderColor: "#f1f1f1" 
+  },
+  rowName: { 
+    fontWeight: "700", 
+    marginBottom: 8,
+    fontSize: responsiveFontSize(16),
+    fontFamily: 'NotoSansKR',
+    color: '#17171B',
+  },
+  rowText: {
+    fontSize: responsiveFontSize(14),
+    fontFamily: 'NotoSansKR',
+    color: '#333',
+    lineHeight: responsiveHeight(22),
+  }
 });
+

--- a/src/screens/station/StationFacilitiesScreen.js
+++ b/src/screens/station/StationFacilitiesScreen.js
@@ -1,4 +1,3 @@
-//src/screens/station/StationFacilitiesScreen.js
 import React, { useEffect, useMemo, useState, useCallback } from "react";
 import {
   View,
@@ -8,40 +7,34 @@ import {
   RefreshControl,
   StyleSheet,
   TouchableOpacity,
-  SafeAreaView,
+  SafeAreaView, // SafeAreaView 추가
 } from "react-native";
 import { useRoute } from "@react-navigation/native";
-
-// 1. 필요한 훅과 유틸리티를 불러옵니다.
 import { useFontSize } from "../../contexts/FontSizeContext";
 import { responsiveFontSize, responsiveHeight } from "../../utils/responsive";
 
-// 역 메타 및 엘리베이터 JSON 데이터
 import stationJson from "../../assets/metro-data/metro/station/data-metro-station-1.0.0.json";
 import elevJson from "../../assets/metro-data/metro/elevator/서울교통공사_교통약자_이용시설_승강기_가동현황.json";
 
-/* --- 유틸 함수 및 데이터 인덱싱 (기존과 동일) --- */
-const sanitizeName = (name = "") => {
+/* ===================== 공통 유틸 ===================== */
+function sanitizeName(name = "") {
   if (typeof name !== "string") return "";
   return name.replace(/\(\s*\d+\s*\)$/g, "").trim();
-};
-const normalizeLine = (line = "") => {
+}
+function normalizeLine(line = "") {
   const s = String(line).trim();
   const m = s.match(/(\d+)/);
   return m ? `${parseInt(m[1], 10)}호선` : s;
-};
-const koKind = (kind = "") => {
+}
+function koKind(kind = "") {
   if (kind === "EV") return "엘리베이터";
   if (kind === "ES") return "에스컬레이터";
   if (kind === "WL") return "휠체어리프트";
   return kind || "-";
-};
+}
 
-const STATION_ROWS = Array.isArray(stationJson?.DATA)
-  ? stationJson.DATA
-  : Array.isArray(stationJson)
-  ? stationJson
-  : [];
+/* ===================== 역 인덱스(정답표) ===================== */
+const STATION_ROWS = Array.isArray(stationJson?.DATA) ? stationJson.DATA : Array.isArray(stationJson) ? stationJson : [];
 const byCode = new Map();
 const byNameLine = new Map();
 const byNameFirst = new Map();
@@ -55,10 +48,7 @@ for (const row of STATION_ROWS) {
   if (line) byNameLine.set(`${name}|${line}`, rec);
   if (!byNameFirst.has(name)) byNameFirst.set(name, rec);
 }
-function findByCode(code) {
-  if (!code) return null;
-  return byCode.get(code) || null;
-}
+function findByCode(code) { if (!code) return null; return byCode.get(code) || null; }
 function findByNameAndLine(name, line) {
   const n = sanitizeName(name);
   const l = normalizeLine(line || "");
@@ -69,6 +59,8 @@ function findByNameAndLine(name, line) {
   }
   return byNameFirst.get(n) || null;
 }
+
+/* ===================== 파라미터 정규화 ===================== */
 function normalizeParams(raw = {}) {
   const nameRaw = raw.name ?? raw.stationName ?? raw.title ?? "";
   const lineRaw = raw.line ?? raw.lineName ?? raw.route ?? raw.ln ?? "";
@@ -78,6 +70,8 @@ function normalizeParams(raw = {}) {
   const code = typeof codeRaw === "string" ? codeRaw.trim() : codeRaw;
   return { name, line, code };
 }
+
+/* ===================== 엘리베이터 JSON 정규화 & 인덱싱 ===================== */
 function pickElevArray(anyJson) {
   if (Array.isArray(anyJson)) return anyJson;
   if (Array.isArray(anyJson?.DATA)) return anyJson.DATA;
@@ -106,19 +100,11 @@ function normalizeElevRow(raw) {
   const statusRaw = raw.use_yn ?? raw.USE_YN ?? raw.status ?? "";
   const kind = raw.elvtr_se ?? raw.ELVTR_SE ?? raw.kind ?? "";
   let line = normalizeLine(raw.line ?? raw.LINE_NUM ?? raw.lineName ?? "");
-
-  const status =
-    statusRaw === "Y"
-      ? "사용가능"
-      : statusRaw === "N"
-      ? "중지"
-      : statusRaw || "-";
-
+  const status = statusRaw === "Y" ? "사용가능" : statusRaw === "N" ? "중지" : statusRaw || "-";
   if (!line && code) {
     const meta = findByCode(code);
     if (meta?.line) line = meta.line;
   }
-
   return { code: code.trim(), name, facilityName, section, location, status, kind, line };
 }
 const ELEV_ROWS = pickElevArray(elevJson).map(normalizeElevRow);
@@ -131,19 +117,20 @@ for (const r of ELEV_ROWS) {
 }
 
 /* ===================== 화면 컴포넌트 ===================== */
-
 export default function StationFacilitiesScreen() {
   const { fontOffset } = useFontSize();
   const route = useRoute();
   const baseParams = useMemo(() => normalizeParams(route?.params), [route?.params]);
-  
-  const [resolved, setResolved] = useState({});
+  const [resolved, setResolved] = useState({
+    code: baseParams.code ?? null,
+    name: baseParams.name ?? "",
+    line: baseParams.line ?? "",
+  });
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState("");
   const [rows, setRows] = useState([]);
 
-  // 👇 [수정] fetchData의 의존성을 baseParams로 변경하여, route.params가 바뀔 때마다 다시 실행되도록 합니다.
   const fetchData = useCallback(
     async (opts = { isRefresh: false }) => {
       try {
@@ -159,42 +146,29 @@ export default function StationFacilitiesScreen() {
             current.code = meta.code;
             if (!current.line) current.line = meta.line;
           }
-        } else if (current.code && !current.line) {
-          const meta = findByCode(current.code);
-          if (meta?.line) current.line = meta.line;
-          if (!current.name && meta?.name) current.name = meta.name;
+        } else if (current.code) {
+           const meta = findByCode(current.code);
+           if (meta) {
+             if(!current.name) current.name = meta.name;
+             if(!current.line) current.line = meta.line;
+           }
         }
-
+        
         let filtered = [];
         if (current.code) {
           filtered = ELEV_BY_CODE.get(current.code) || [];
         }
         if (filtered.length === 0 && current.name) {
           const n = sanitizeName(current.name);
-          filtered = ELEV_ROWS.filter((r) => sanitizeName(r.name) === n);
-        }
-
-        if ((!current.name || !current.line) && filtered.length) {
-          const r0 = filtered[0];
-          current.name = sanitizeName(current.name || r0.name || "");
-          if (!current.line) current.line = r0.line || current.line || "";
-        }
-        if (!current.name || !current.line) {
-          const meta = current.code
-            ? findByCode(current.code)
-            : findByNameAndLine(current.name, current.line);
-          if (meta) {
-            if (!current.name) current.name = meta.name;
-            if (!current.line) current.line = meta.line;
-          }
+          filtered = ELEV_ROWS.filter((r) => sanitizeName(r.name) === n && (!current.line || r.line === current.line));
         }
 
         setResolved(current);
         setRows(filtered);
 
         if (filtered.length === 0) {
-          const msg = current.code || current.name
-            ? `해당 역 설비 데이터가 없습니다. (${current.line || ""} ${current.name || ""} / 코드 ${current.code || "-"})`
+          const msg = current.name || current.code
+            ? `해당 역 설비 데이터가 없습니다.`
             : "표시할 데이터가 없습니다.";
           setError(msg);
         }
@@ -206,10 +180,9 @@ export default function StationFacilitiesScreen() {
         else setLoading(false);
       }
     },
-    [baseParams] // fetchData는 baseParams가 변경될 때만 새로 생성됩니다.
+    [baseParams]
   );
-
-  // 👇 [수정] useEffect가 fetchData 함수 자체의 변경을 감지하도록 수정합니다.
+  
   useEffect(() => {
     fetchData();
   }, [fetchData]);
@@ -222,10 +195,9 @@ export default function StationFacilitiesScreen() {
     return (
       <View style={s.card}>
         <Text style={[s.cardTitle, { fontSize: responsiveFontSize(16) + fontOffset }]}>
-          {sanitizeName(item.name)} ({item.code})
+          {item.facilityName}
         </Text>
         <Text style={[s.meta, { fontSize: responsiveFontSize(14) + fontOffset }]}>라인: {item.line || resolved.line || "-"}</Text>
-        <Text style={[s.meta, { fontSize: responsiveFontSize(14) + fontOffset }]}>시설명: {item.facilityName || "-"}</Text>
         <Text style={[s.meta, { fontSize: responsiveFontSize(14) + fontOffset }]}>종류: {koKind(item.kind)}</Text>
         <Text style={[s.meta, { fontSize: responsiveFontSize(14) + fontOffset }]}>상태: {item.status}</Text>
         <Text style={[s.meta, { fontSize: responsiveFontSize(14) + fontOffset }]}>설치위치: {item.location || "-"}</Text>
@@ -238,9 +210,7 @@ export default function StationFacilitiesScreen() {
     return (
       <SafeAreaView style={s.center}>
         <ActivityIndicator />
-        <Text style={[s.centerText, { fontSize: responsiveFontSize(16) + fontOffset, marginTop: 8 }]}>
-          불러오는 중…
-        </Text>
+        <Text style={[s.centerText, { marginTop: 8, fontSize: responsiveFontSize(16) + fontOffset }]}>불러오는 중…</Text>
       </SafeAreaView>
     );
   }
@@ -284,10 +254,10 @@ export default function StationFacilitiesScreen() {
 
 const s = StyleSheet.create({
   container: { flex: 1, backgroundColor: "#fff" },
-  center: { flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: '#fff' },
+  center: { flex: 1, alignItems: "center", justifyContent: "center", padding: 16, backgroundColor: '#fff' },
   centerText: {
     fontFamily: 'NotoSansKR',
-    fontWeight: '500',
+    fontWeight: 'bold',
     color: '#333'
   },
   header: {
@@ -297,8 +267,8 @@ const s = StyleSheet.create({
     borderColor: "#eee",
     backgroundColor: "#fafafa",
   },
-  headerTitle: { fontSize: responsiveFontSize(18), fontWeight: "700", color: "#111", fontFamily: 'NotoSansKR' },
-  headerSub: { marginTop: 4, color: "#666", fontSize: responsiveFontSize(14), fontFamily: 'NotoSansKR' },
+  headerTitle: { fontSize: 18, fontWeight: "bold", color: "#111", fontFamily: 'NotoSansKR' },
+  headerSub: { marginTop: 4, color: "#666", fontFamily: 'NotoSansKR', fontWeight: 'bold' },
   errorBox: {
     marginHorizontal: 16,
     marginTop: 12,
@@ -308,8 +278,8 @@ const s = StyleSheet.create({
     borderWidth: 1,
     borderColor: "#FFD6CC",
   },
-  errorText: { color: "#B71C1C", fontSize: responsiveFontSize(14), fontFamily: 'NotoSansKR' },
-  retry: { marginTop: 8, fontWeight: "700", color: "#14CAC9", fontSize: responsiveFontSize(14), fontFamily: 'NotoSansKR' },
+  errorText: { color: "#B71C1C", fontFamily: 'NotoSansKR', fontWeight: 'bold' },
+  retry: { marginTop: 8, fontWeight: "bold", color: "#14CAC9", fontFamily: 'NotoSansKR' },
   card: {
     padding: 12,
     borderRadius: 12,
@@ -318,7 +288,7 @@ const s = StyleSheet.create({
     marginBottom: 12,
     backgroundColor: "#fff",
   },
-  cardTitle: { fontSize: responsiveFontSize(16), fontWeight: "700", marginBottom: 6, color: "#111", fontFamily: 'NotoSansKR' },
-  meta: { color: "#333", marginBottom: 2, fontSize: responsiveFontSize(14), fontFamily: 'NotoSansKR', lineHeight: responsiveHeight(20) },
+  cardTitle: { fontSize: 16, fontWeight: "bold", marginBottom: 6, color: "#111", fontFamily: 'NotoSansKR' },
+  meta: { color: "#333", marginBottom: 2, fontFamily: 'NotoSansKR', fontWeight: 'bold' },
 });
 


### PR DESCRIPTION
캡쳐본이랑 비교해보고 잘되면 merge 부탁용


목표: 앱의 접근성 향상을 위해, 고령층 및 저시력 사용자가 앱 내 모든 텍스트의 크기를 직접 조절할 수 있는 동적 글자 크기 조절 기능을 구현했습니다.

핵심 기능:

사용자는 설정 모달을 통해 '작게', '보통', '크게', '아주 크게' 4단계로 글자 크기를 선택할 수 있습니다.

로그인/비로그인 상태에 따라 설정값이 영구적으로 저장됩니다.

앱의 모든 화면(헤더, 탭 바 포함)에 선택된 글자 크기가 일관되게 적용됩니다.



1. 비로그인시

홈
<img width="467" height="1005" alt="스크린샷 2025-10-11 211805" src="https://github.com/user-attachments/assets/a8aece11-bc99-4ef3-93d6-19d5b5e35484" />

<크기조절은 로그인 비로그인 공통임미다.>
작게
<img width="476" height="1020" alt="스크린샷 2025-10-11 211835" src="https://github.com/user-attachments/assets/e2418baf-5361-4603-b507-a307673d7873" />

보통

<img width="461" height="1006" alt="스크린샷 2025-10-11 211825" src="https://github.com/user-attachments/assets/ab5cf953-d545-494d-be20-cdf75b8f59d6" />

크게
<img width="482" height="1041" alt="스크린샷 2025-10-11 211849" src="https://github.com/user-attachments/assets/b1d7b508-1e11-4c8f-8d14-69bcd2c357dd" />

아주크게

<img width="476" height="1019" alt="스크린샷 2025-10-11 211902" src="https://github.com/user-attachments/assets/0d7873aa-ea44-45d4-81a8-c2738148251f" />


2. 로그인시

홈

<img width="478" height="1022" alt="스크린샷 2025-10-11 212137" src="https://github.com/user-attachments/assets/0ff92249-e012-45ac-8833-2da33e3ce364" />


마이
<img width="473" height="1033" alt="스크린샷 2025-10-11 212145" src="https://github.com/user-attachments/assets/d4b410c7-cf3b-40d0-819c-ec186eb115ef" />




//아래는 잼민이가 설명해준 기능임미다. gpt에 학습시켜서 누리링 필요할때 꺼내써도 좋을듯요



✨ PR 유형
[x] 새로운 기능 추가

[x] 버그 수정

[x] UI 디자인 변경

[x] 코드 리팩토링

📝 개요
목표: 앱의 접근성 향상을 위해, 고령층 및 저시력 사용자가 앱 내 모든 텍스트의 크기를 직접 조절할 수 있는 동적 글자 크기 조절 기능을 구현했습니다.

핵심 기능:

사용자는 설정 모달을 통해 '작게', '보통', '크게', '아주 크게' 4단계로 글자 크기를 선택할 수 있습니다.

로그인/비로그인 상태에 따라 설정값이 영구적으로 저장됩니다.

앱의 모든 화면(헤더, 탭 바 포함)에 선택된 글자 크기가 일관되게 적용됩니다.

👨‍💻 작업 내용
1. 전역 상태 관리 및 데이터 저장
FontSizeContext 도입: React Context API를 사용하여 글자 크기 변화량(fontOffset)을 앱 전역에서 공유할 수 있도록 FontSizeProvider와 useFontSize 훅을 구현했습니다.

로그인 상태에 따른 데이터 분리 저장:

로그인 사용자: Firebase Firestore의 users 컬렉션 내 accessibilityProfile.fontScale 필드에 fontOffset 값을 저장합니다. 이를 통해 다른 기기에서 로그인해도 동일한 설정이 유지됩니다.

비로그인 사용자: @react-native-async-storage/async-storage를 사용하여 사용자의 기기에 설정을 저장합니다. 앱을 재시작해도 설정이 유지됩니다.

2. UI 및 접근성 개선
FontSettingModal 컴포넌트: 재사용 가능한 글자 크기 설정 모달을 제작했습니다.

UI 개선: 현재 선택된 옵션을 명확히 보여주는 2x2 그리드 레이아웃과 터치 영역이 넓은 버튼을 적용하여 사용 편의성을 높였습니다.

TalkBack 접근성 강화: accessibilityRole, accessibilityLabel, accessibilityState 속성을 적용하여, 스크린 리더 사용자에게 "선택됨, 글자 크기를 보통으로 설정, 버튼"과 같이 명확한 음성 안내를 제공합니다.

3. 전역 스타일 적용
동적 스타일 적용: App.js의 모든 네비게이터(Stack, Tab)와 각 화면 및 공용 컴포넌트(CustomButton, AuthInput 등)에 useFontSize 훅을 적용하여, fontOffset 값에 따라 fontSize, 아이콘 크기, 탭 바 높이 등이 동적으로 변경되도록 리팩토링했습니다.

폰트 일관성 확보: 모든 텍스트의 fontWeight를 'bold'로 통일하여, 커스텀 폰트(NotoSansKR)가 모든 기기에서 일관된 두께로 보이도록 수정했습니다.

4. 버그 수정
StationDetailScreen / StationFacilitiesScreen: 데이터 로딩 로직의 의존성 문제를 해결하여, 역 정보(특히 역 코드)가 정상적으로 표시되도록 버그를 수정했습니다.

ChatBotScreen: useEffect 및 useCallback 의존성 문제를 해결하여, 초기 메시지 미표시 및 메시지 전송 불가 버그를 수정했습니다.

SearchStationScreen: TextInput의 고정 높이 문제를 해결하여, 글자 크기가 커져도 입력창이 잘리지 않도록 수정했습니다.

📺 스크린샷 (선택)
(여기에 기능 시연 GIF나 스크린샷을 첨부하면 리뷰어가 이해하기 더 좋습니다.)

모달 UI:

글자 크기 변경 전/후 비교:

🧪 테스트 방법
앱 실행 후, 비로그인 상태에서 홈 화면의 '글자 크기 설정' 버튼을 눌러 모달을 엽니다.

'크게'를 선택하고, 홈 화면, 주변, 검색 등 여러 화면의 글자 크기가 커지는지 확인합니다.

앱을 완전히 종료했다가 다시 켜도, 커진 글자 크기가 유지되는지 확인합니다.

로그인 후, 마이페이지의 '글자 크기 설정' 버튼을 눌러 '작게'로 변경합니다.

모든 화면의 글자 크기가 작아지는지 확인합니다.

로그아웃 후 다시 로그인했을 때, '작게' 설정이 Firebase에서 정상적으로 불러와지는지 확인합니다.

(선택) Android TalkBack을 켜고 모달의 버튼을 터치하여 음성 안내가 올바르게 나오는지 확인합니다.

✍️ 기타 사항
이번 작업을 통해 앱의 핵심 목표 중 하나인 '높은 디지털 접근성 보장'을 크게 향상시켰습니다.

코드 리뷰 시, 특히 App.js의 네비게이터 스타일링 부분과 FontSizeContext의 로직을 중점적으로 봐주시면 감사하겠습니다.


