### PR TITLE
교통약자_이용시설_승강기_가동현황 API 연결완. 테스트 화면 생성 (app.js에 주석처리해놓음)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,5 @@
 {
-  "recommendations": ["denoland.vscode-deno"]
+  "recommendations": [
+    "denoland.vscode-deno"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  "[typescript]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
   "deno.enable": true,
   "deno.enablePaths": [
     "supabase/functions"
@@ -19,7 +22,8 @@
     "http",
     "net"
   ],
-  "[typescript]": {
-    "editor.defaultFormatter": "denoland.vscode-deno"
+  "deno.suggest.imports.hosts": {
+    "https://deno.land": true,
+    "https://esm.sh": true
   }
 }

--- a/App.js
+++ b/App.js
@@ -14,6 +14,7 @@ import { GoogleSignin } from '@react-native-google-signin/google-signin';
 import { AuthProvider, useAuth } from './src/contexts/AuthContext';
 import { FontSizeProvider, useFontSize } from './src/contexts/FontSizeContext';
 import { responsiveFontSize } from './src/utils/responsive';
+import MetroTestScreen from "./src/screens/test/metroTestScreen";
 
 // --- 화면들 ---
 import WelcomeScreen from './src/screens/auth/WelcomeScreen';
@@ -336,12 +337,13 @@ const AppContent = () => {
       </View>
     );
   }
-
-  return (
+// return <MetroTestScreen />;//api 테스트용
+return (
     <NavigationContainer>
       {user ? <AppStack /> : <AuthStack />}
     </NavigationContainer>
-  );
+  ); 
+  
 };
 
 export default function App() {

--- a/src/api/metroAPI.js
+++ b/src/api/metroAPI.js
@@ -1,4 +1,4 @@
-// metroAPI.js
+// src/api/metroAPI.js
 import { SUPABASE_URL } from "../constants/constants";
 
 export async function getEscalatorStatus() {

--- a/src/api/metroAPI.js
+++ b/src/api/metroAPI.js
@@ -1,0 +1,15 @@
+// metroAPI.js
+import { SUPABASE_URL } from "../constants/constants";
+
+export async function getEscalatorStatus() {
+  try {
+    const res = await fetch(`${SUPABASE_URL}/functions/v1/metro-escalators`, {
+      headers: { "Content-Type": "application/json" },
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return await res.json();
+  } catch (e) {
+    console.error("API fetch error:", e);
+    throw e;
+  }
+}

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -1,0 +1,3 @@
+export const SUPABASE_URL = "https://utqfwkhxacqhgjjalpby.supabase.co";
+export const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+export const SEOUL_OPEN_API_KEY = process.env.EXPO_PUBLIC_SEOUL_API_KEY;

--- a/src/screens/station/StationDetailScreen.js
+++ b/src/screens/station/StationDetailScreen.js
@@ -1,3 +1,4 @@
+// src/screens/station/StationDetailScreen.js
 import React, { useMemo, useEffect, useState } from "react";
 import {
   View, Text, TouchableOpacity, StyleSheet, ScrollView, StatusBar, Alert

--- a/src/screens/station/StationFacilitiesScreen.js
+++ b/src/screens/station/StationFacilitiesScreen.js
@@ -1,3 +1,4 @@
+// src/screens/station/StationFacilitiesScreen.js
 import React, { useEffect, useMemo, useState } from "react";
 import {
   View, Text, StyleSheet, FlatList, TouchableOpacity, SafeAreaView, ActivityIndicator, StatusBar, Alert,

--- a/src/screens/test/metroTestScreen.js
+++ b/src/screens/test/metroTestScreen.js
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from "react";
+import { View, Text, ActivityIndicator } from "react-native";
+import { getEscalatorStatus } from "../../api/metroAPI";
+import { SUPABASE_URL } from "../../constants/constants";
+
+export default function MetroTestScreen() {
+  const [loading, setLoading] = useState(true);
+  const [escalators, setEscalators] = useState([]);
+
+  useEffect(() => {
+    console.log("🚀 환경변수 URL:", process.env.EXPO_PUBLIC_SUPABASE_URL);
+    console.log("📡 SUPABASE_URL:", SUPABASE_URL);
+
+    (async () => {
+      try {
+        const data = await getEscalatorStatus();
+        setEscalators(data);
+        console.log("✅ Supabase API 호출 성공:", data.length, "건");
+      } catch (e) {
+        console.error("❌ API fetch error:", e);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  if (loading) {
+    return (
+      <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+        <ActivityIndicator size="large" />
+        <Text>지하철 에스컬레이터 정보 불러오는 중...</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={{ flex: 1, padding: 20 }}>
+      <Text style={{ fontSize: 18, fontWeight: "bold", marginBottom: 10 }}>
+        ✅ 불러온 데이터 ({escalators.length}개)
+      </Text>
+      {escalators.slice(0, 3).map((item, idx) => (
+        <Text key={idx}>
+          {item.stationName} - {item.elevatorName} ({item.status})
+        </Text>
+      ))}
+    </View>
+  );
+}

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -6,3 +6,12 @@
 .env.keys
 .env.local
 .env.*.local
+
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -346,5 +346,13 @@ s3_access_key = "env(S3_ACCESS_KEY)"
 # Configures AWS_SECRET_ACCESS_KEY for S3 bucket
 s3_secret_key = "env(S3_SECRET_KEY)"
 
-[functions."elev-status"]
-verify_jwt = false
+[functions.metro-escalators]
+enabled = true
+verify_jwt = true
+import_map = "./functions/metro-escalators/deno.json"
+# Uncomment to specify a custom file path to the entrypoint.
+# Supported file extensions are: .ts, .js, .mjs, .jsx, .tsx
+entrypoint = "./functions/metro-escalators/index.ts"
+# Specifies static files to be bundled with the function. Supports glob patterns.
+# For example, if you want to serve static HTML pages in your function:
+# static_files = [ "./functions/metro-escalators/*.html" ]

--- a/supabase/functions/metro-escalators/.npmrc
+++ b/supabase/functions/metro-escalators/.npmrc
@@ -1,0 +1,3 @@
+# Configuration for private npm package dependencies
+# For more information on using private registries with Edge Functions, see:
+# https://supabase.com/docs/guides/functions/import-maps#importing-from-private-registries

--- a/supabase/functions/metro-escalators/deno.json
+++ b/supabase/functions/metro-escalators/deno.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://deno.land/x/deno@v1.41.0/cli/schemas/config-file.v1.json",
+
+  "imports": {
+    "@supabase/functions-js": "https://esm.sh/@supabase/functions-js@1.3.3",
+    "xml": "https://deno.land/x/xml@2.1.0/mod.ts"
+  },
+
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"]
+  },
+
+  "lint": {
+    "rules": {
+      "tags": ["recommended"],
+      "exclude": [
+        "no-explicit-any",
+        "no-unused-vars",
+        "no-import-prefix",
+        "no-unversioned-import"
+      ]
+    }
+  },
+
+  "tasks": {
+    "start": "deno run --allow-net --allow-env index.ts"
+  }
+}

--- a/supabase/functions/metro-escalators/index.ts
+++ b/supabase/functions/metro-escalators/index.ts
@@ -1,0 +1,50 @@
+/// <reference lib="deno.ns" />
+
+// Deno 환경 호환되는 경량 XML 파서
+import { parse } from "https://deno.land/x/xml@2.1.0/mod.ts";
+
+Deno.serve(async (_req: Request) => {
+  try {
+    const API_KEY = Deno.env.get("SEOUL_OPEN_API_KEY");
+    if (!API_KEY) {
+      return new Response(JSON.stringify({ error: "Missing SEOUL_OPEN_API_KEY" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // 서울교통공사_교통약자_이용시설_승강기_가동현황 (XML)
+    const url = `http://openapi.seoul.go.kr:8088/${API_KEY}/xml/SeoulMetroFaciInfo/1/100/`;
+    const res = await fetch(url);
+    if (!res.ok) {
+      return new Response(JSON.stringify({ error: `Open API HTTP ${res.status}` }), {
+        status: res.status,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const xmlText = await res.text();
+    const xmlObj: any = parse(xmlText);
+    const rows = xmlObj?.SeoulMetroFaciInfo?.row ?? [];
+
+    const data = rows.map((item: Record<string, string>) => ({
+      stationCode: Number(item.STN_CD),
+      stationName: item.STN_NM,
+      elevatorName: item.ELVTR_NM,
+      section: item.OPR_SEC,
+      position: item.INSTL_PSTN,
+      status: item.USE_YN,
+      type: item.ELVTR_SE,
+    }));
+
+    return new Response(JSON.stringify(data), {
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+});


### PR DESCRIPTION
API 연결해놨구 테스트화면으로 테스트까지 해봤옹  공공데이터 api key(실시간 api 키 발급 받아서 넣으면 됨)랑 supabase anon키(project setting -> API key 들어가면 첫번째꺼) 넣은 다음에 App.js에 있는 MetroTestScreen 주석 되어있는거 풀고 아래 코드에 주석 처리해서 실행해보면 뜹니당

//현재상태
// return <MetroTestScreen />;//api 테스트용
return (
    <NavigationContainer>
      {user ? <AppStack /> : <AuthStack />}
    </NavigationContainer>
  ); 
  
};

//테스트할때
return <MetroTestScreen />;//api 테스트용
/**return (
    <NavigationContainer>
      {user ? <AppStack /> : <AuthStack />}
    </NavigationContainer>
  ); 
  
};**/



글구 잘 모르겠음 아래 내용 그대로 복사해서 gpt한테 학습시키면 돼!


🧠 Pull Request: Supabase Edge Function 연동 및 MetroTestScreen 추가
🏗️ 목적 (Purpose)

이 PR은 지하철 에스컬레이터/엘리베이터 정보를 Supabase Edge Function을 통해 불러오는 시스템을 구축하기 위한 첫 단계입니다.
Supabase Functions를 사용해 XML → JSON 변환 API를 구현하고, React Native 앱에서 이를 테스트할 수 있도록 구성했습니다.

🧩 변경사항 요약 (Summary of Changes)
📁 Supabase Function

supabase/functions/metro-escalators/index.ts

서울 열린데이터 광장의 XML API를 호출 → JSON으로 변환 후 반환

Edge Function으로 배포 (https://utqfwkhxacqhgjjalpby.supabase.co/functions/v1/metro-escalators)

supabase/functions/metro-escalators/deno.json

Deno 환경 설정 (타입 선언, 린트 설정 포함)

📱 React Native App

utils/constants.js
→ SUPABASE_URL은 하드코딩 (공개 안전),
→ SUPABASE_ANON_KEY와 서울공공데이터 API KEY는 .env에서 불러오도록 변경.

utils/metroAPI.js
→ Supabase Edge Function에 fetch 요청 보내는 모듈.

screens/test/MetroTestScreen.js
→ API 응답 테스트용 화면. (실제 앱 구조에는 포함되지 않음)

App.js
→ 현재 MetroTestScreen만 임시 실행되도록 설정.
나중에 전체 네비게이션 복귀 시 return <MetroTestScreen />; 주석만 제거하면 원상복구 가능.

⚙️ 환경변수 구성 (.env)
EXPO_PUBLIC_SUPABASE_ANON_KEY=<your_anon_key>
EXPO_PUBLIC_SEOUL_API_KEY=<your_seoul_api_key>


⚠️ SUPABASE_URL은 공개 가능한 값으로 constants.js에 하드코딩 되어 있음.
.env는 반드시 .gitignore에 포함되어 있어 깃허브에는 업로드되지 않음.

🧪 테스트 방법 (Test Steps)

.env 파일 생성 후 위 예시 내용 입력

npm start 또는 expo start 실행

MetroTestScreen이 로드되며 콘솔에 다음 출력 확인

✅ Supabase API 호출 성공: N건


실제 화면에도 일부 데이터(예: 역명, 에스컬레이터명, 상태)가 표시됨

📸 참고 스크린샷 (optional)

✅ 지하철 에스컬레이터 정보 불러오는 중...
✅ 정상 출력 시 서울역(1) - 승강기)에스컬레이터 1 (사용가능) 등 표시

🚀 다음 단계 (Next Steps)

 MetroTestScreen 제거 후 MainScreen에서 실데이터 연동

 검색/역 상세 화면에 Supabase API 통합

 Error Boundary 및 로딩 UI 공통 컴포넌트화

🤖 GPT 협업 가이드 (for teammate’s GPT)

이 PR은 Supabase Function ↔ React Native 간 연결 구조의 초기 구현입니다.
후속 GPT 프롬프트는 다음 문장을 기준으로 시작하면 됩니다:

"Supabase Edge Function을 통해 metro-escalators 데이터를 가져와 역 상세 페이지에 통합해주세요."


→ GPT는 metroAPI.js를 참조하여 API fetch 구조를 그대로 확장하면 됩니다.

브랜치: feature/supabase-function
머지 대상: develop (또는 main, 팀 정책에 맞게)
테스트 환경: Expo SDK 51 / Deno 1.45+ / Supabase CLI 2.47+